### PR TITLE
Feature/brain and attachment update

### DIFF
--- a/Assets/_Project/Materials/Graybox/Material - Metal Surface.mat
+++ b/Assets/_Project/Materials/Graybox/Material - Metal Surface.mat
@@ -277,7 +277,7 @@ Material:
     - _StencilWriteMask: 6
     - _StencilWriteMaskDepth: 8
     - _StencilWriteMaskGBuffer: 14
-    - _StencilWriteMaskMV: 42
+    - _StencilWriteMaskMV: 40
     - _SubsurfaceMask: 1
     - _SupportDecals: 1
     - _Surface: 0

--- a/Assets/_Project/Materials/HDRP-samples/Materials/ReferenceBlackArtificialRough.mat
+++ b/Assets/_Project/Materials/HDRP-samples/Materials/ReferenceBlackArtificialRough.mat
@@ -240,7 +240,7 @@ Material:
     - _StencilWriteMaskDepth: 8
     - _StencilWriteMaskDistortionVec: 4
     - _StencilWriteMaskGBuffer: 14
-    - _StencilWriteMaskMV: 40
+    - _StencilWriteMaskMV: 42
     - _Stiffness: 1
     - _SubsurfaceMask: 1
     - _SupportDecals: 1

--- a/Assets/_Project/Materials/HDRP-samples/Materials/ReferenceBlackArtificialRough.mat
+++ b/Assets/_Project/Materials/HDRP-samples/Materials/ReferenceBlackArtificialRough.mat
@@ -240,7 +240,7 @@ Material:
     - _StencilWriteMaskDepth: 8
     - _StencilWriteMaskDistortionVec: 4
     - _StencilWriteMaskGBuffer: 14
-    - _StencilWriteMaskMV: 42
+    - _StencilWriteMaskMV: 40
     - _Stiffness: 1
     - _SubsurfaceMask: 1
     - _SupportDecals: 1

--- a/Assets/_Project/Materials/HoloMats/HoloLitGlow/HoloGlowOrange.mat
+++ b/Assets/_Project/Materials/HoloMats/HoloLitGlow/HoloGlowOrange.mat
@@ -281,7 +281,7 @@ Material:
     - _StencilWriteMask: 6
     - _StencilWriteMaskDepth: 8
     - _StencilWriteMaskGBuffer: 14
-    - _StencilWriteMaskMV: 42
+    - _StencilWriteMaskMV: 40
     - _SubsurfaceMask: 1
     - _SupportDecals: 0
     - _Surface: 0

--- a/Assets/_Project/Materials/HoloMats/HoloLitGlow/HoloGlowOrange.mat
+++ b/Assets/_Project/Materials/HoloMats/HoloLitGlow/HoloGlowOrange.mat
@@ -182,7 +182,7 @@ Material:
     - _AORemapMin: 0
     - _ATDistance: 1
     - _AddPrecomputedVelocity: 0
-    - _AlbedoAffectEmissive: 0
+    - _AlbedoAffectEmissive: 1
     - _AlphaClip: 0
     - _AlphaCutoff: 0.5
     - _AlphaCutoffEnable: 0
@@ -281,7 +281,7 @@ Material:
     - _StencilWriteMask: 6
     - _StencilWriteMaskDepth: 8
     - _StencilWriteMaskGBuffer: 14
-    - _StencilWriteMaskMV: 42
+    - _StencilWriteMaskMV: 40
     - _SubsurfaceMask: 1
     - _SupportDecals: 0
     - _Surface: 0
@@ -300,7 +300,7 @@ Material:
     - _UVBase: 0
     - _UVDetail: 0
     - _UVEmissive: 0
-    - _UseEmissiveIntensity: 1
+    - _UseEmissiveIntensity: 0
     - _UseShadowThreshold: 0
     - _WorkflowMode: 1
     - _ZTestDepthEqualForOpaque: 3
@@ -314,7 +314,7 @@ Material:
     - _DiffusionProfileAsset: {r: 0, g: 0, b: 0, a: 0}
     - _DoubleSidedConstants: {r: 1, g: 1, b: -1, a: 0}
     - _EmissionColor: {r: 1, g: 1, b: 1, a: 1}
-    - _EmissiveColor: {r: 14.9803915, g: 8.941176, b: 2.35294, a: 20}
+    - _EmissiveColor: {r: 1, g: 1, b: 1, a: 20}
     - _EmissiveColorLDR: {r: 0.88031507, g: 0.69934684, b: 0.37750837, a: 1}
     - _InvPrimScale: {r: 1, g: 1, b: 0, a: 0}
     - _IridescenceThicknessRemap: {r: 0, g: 1, b: 0, a: 0}

--- a/Assets/_Project/Materials/HoloMats/HoloLitGlow/HoloGlowOrange.mat
+++ b/Assets/_Project/Materials/HoloMats/HoloLitGlow/HoloGlowOrange.mat
@@ -281,7 +281,7 @@ Material:
     - _StencilWriteMask: 6
     - _StencilWriteMaskDepth: 8
     - _StencilWriteMaskGBuffer: 14
-    - _StencilWriteMaskMV: 40
+    - _StencilWriteMaskMV: 42
     - _SubsurfaceMask: 1
     - _SupportDecals: 0
     - _Surface: 0

--- a/Assets/_Project/Materials/HoloMats/HoloSpawner.mat
+++ b/Assets/_Project/Materials/HoloMats/HoloSpawner.mat
@@ -12,14 +12,14 @@ Material:
   m_ValidKeywords:
   - _DISABLE_DECALS
   - _DISABLE_SSR_TRANSPARENT
-  - _DOUBLESIDED_ON
+  - _EMISSIVE_COLOR_MAP
   - _MASKMAP
   - _NORMALMAP
   m_InvalidKeywords:
   - _TESSELLATION_PHONG
   m_LightmapFlags: 1
   m_EnableInstancingVariants: 0
-  m_DoubleSidedGI: 1
+  m_DoubleSidedGI: 0
   m_CustomRenderQueue: 2000
   stringTagMap: {}
   disabledShaderPasses:
@@ -80,7 +80,7 @@ Material:
         m_Scale: {x: 1, y: 1}
         m_Offset: {x: 0, y: 0}
     - _EmissiveColorMap:
-        m_Texture: {fileID: 2800000, guid: 9d66afb7ebe88c446b4629bbcae5b4cf, type: 3}
+        m_Texture: {fileID: 2800000, guid: 0f7365f1c274f70438192602f6ea8d8f, type: 3}
         m_Scale: {x: 1, y: 1}
         m_Offset: {x: 0, y: 0}
     - _HeightMap:
@@ -188,8 +188,8 @@ Material:
     - _ClearCoatSmoothness: 0
     - _CoatMask: 0
     - _Cull: 2
-    - _CullMode: 0
-    - _CullModeForward: 0
+    - _CullMode: 2
+    - _CullModeForward: 2
     - _Cutoff: 0.5
     - _DepthOffsetEnable: 0
     - _DetailAlbedoMapScale: 1
@@ -202,12 +202,12 @@ Material:
     - _DisplacementLockObjectScale: 1
     - _DisplacementLockTilingScale: 1
     - _DisplacementMode: 0
-    - _DoubleSidedEnable: 1
+    - _DoubleSidedEnable: 0
     - _DoubleSidedGIMode: 0
     - _DoubleSidedNormalMode: 1
     - _DstBlend: 0
     - _EmissiveColorMode: 1
-    - _EmissiveExposureWeight: 0
+    - _EmissiveExposureWeight: 0.726
     - _EmissiveIntensity: 20
     - _EmissiveIntensityUnit: 0
     - _EnableBlendModePreserveSpecularLighting: 1
@@ -268,7 +268,7 @@ Material:
     - _StencilWriteMask: 6
     - _StencilWriteMaskDepth: 8
     - _StencilWriteMaskGBuffer: 14
-    - _StencilWriteMaskMV: 42
+    - _StencilWriteMaskMV: 40
     - _SubsurfaceMask: 1
     - _SupportDecals: 0
     - _Surface: 0
@@ -308,7 +308,7 @@ Material:
     - _DiffusionProfileAsset: {r: 0, g: 0, b: 0, a: 0}
     - _DoubleSidedConstants: {r: 1, g: 1, b: -1, a: 0}
     - _EmissionColor: {r: 1, g: 1, b: 1, a: 1}
-    - _EmissiveColor: {r: 0.29803923, g: 0.20784314, b: 0.7490196, a: 20}
+    - _EmissiveColor: {r: 0.87058824, g: 0.6901961, b: 0.37254903, a: 1}
     - _EmissiveColorLDR: {r: 0.5785821, g: 0.49324608, b: 0.88031507, a: 1}
     - _InvPrimScale: {r: 1, g: 1, b: 0, a: 0}
     - _IridescenceThicknessRemap: {r: 0, g: 1, b: 0, a: 0}

--- a/Assets/_Project/Prefabs/Spawnables/GlowEmitter.prefab
+++ b/Assets/_Project/Prefabs/Spawnables/GlowEmitter.prefab
@@ -289,237 +289,133 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: ae83aa2f25cab0049b0b46e068f56707, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  _EntityType: 0
-  _EntityIndex: 2147483647
-  _EntityInitialised: 0
-  _ManagerInitialised: 0
+  _AudioAsset: {fileID: 11400000, guid: 1afd685b22b5c314eb4665ebe9dfacde, type: 2}
   _Host: {fileID: 6617646643115203077}
   _EmitterType: 0
   _PlaybackCondition: 2
-  _AudioAsset: {fileID: 11400000, guid: 1afd685b22b5c314eb4665ebe9dfacde, type: 2}
   _VolumeAdjust: 0.3
   _DistanceAttenuationFactor: 0.6
   _AgeFadeout: 0.98
   _PingPongGrainPlayheads: 1
-  _ColliderRigidityVolumeScale: 0
-  _ModulationInputs:
-  - _ValueSource: 1
-    _SceneProperties: 0
-    _PrimaryActor: 3
-    _LinkedActors: 3
-    _ActorCollisions: 1
-    _InputValue: 0
-    _InputRange: {x: 0, y: 1}
-    _AdjustMultiplier: 1
-    _OnNewValue: 0
-    _PreSmoothValue: 0
-    _Smoothing: 0.2
-    _InputLimiter: 0
-    _FlipOutput: 0
-    _OutputValue: 0
-  - _ValueSource: 1
-    _SceneProperties: 0
-    _PrimaryActor: 3
-    _LinkedActors: 3
-    _ActorCollisions: 1
-    _InputValue: 0
-    _InputRange: {x: 0, y: 1}
-    _AdjustMultiplier: 1
-    _OnNewValue: 0
-    _PreSmoothValue: 0
-    _Smoothing: 0.2
-    _InputLimiter: 0
-    _FlipOutput: 0
-    _OutputValue: 0
-  - _ValueSource: 1
-    _SceneProperties: 0
-    _PrimaryActor: 3
-    _LinkedActors: 3
-    _ActorCollisions: 1
-    _InputValue: 0
-    _InputRange: {x: 0, y: 1}
-    _AdjustMultiplier: 1
-    _OnNewValue: 0
-    _PreSmoothValue: 0
-    _Smoothing: 0.2
-    _InputLimiter: 0
-    _FlipOutput: 0
-    _OutputValue: 0
-  - _ValueSource: 1
-    _SceneProperties: 0
-    _PrimaryActor: 3
-    _LinkedActors: 3
-    _ActorCollisions: 1
-    _InputValue: 0
-    _InputRange: {x: 0, y: 1}
-    _AdjustMultiplier: 1
-    _OnNewValue: 0
-    _PreSmoothValue: 0
-    _Smoothing: 0.2
-    _InputLimiter: 0
-    _FlipOutput: 0
-    _OutputValue: 0
-  - _ValueSource: 1
-    _SceneProperties: 0
-    _PrimaryActor: 3
-    _LinkedActors: 3
-    _ActorCollisions: 1
-    _InputValue: 0
-    _InputRange: {x: 0, y: 1}
-    _AdjustMultiplier: 1
-    _OnNewValue: 0
-    _PreSmoothValue: 0
-    _Smoothing: 0.2
-    _InputLimiter: 0
-    _FlipOutput: 0
-    _OutputValue: 0
-  - _ValueSource: 1
-    _SceneProperties: 0
-    _PrimaryActor: 3
-    _LinkedActors: 3
-    _ActorCollisions: 1
-    _InputValue: 0
-    _InputRange: {x: 0, y: 1}
-    _AdjustMultiplier: 1
-    _OnNewValue: 0
-    _PreSmoothValue: 0
-    _Smoothing: 0.2
-    _InputLimiter: 0
-    _FlipOutput: 0
-    _OutputValue: 0
+  _CollisionRigidityScaleVolume: 0
   _DSPChainParams: []
   _IsPlaying: 1
   _AdjustedDistance: 0
   _DistanceAmplitude: 0
-  _ContactSurfaceAttenuation: 1
+  _ColliderRigidityVolume: 1
   _LastTriggeredAt: 0
   _LastSampleIndex: 0
-  _Properties:
-    _Volume:
-      _ModulationSource:
-        _ValueSource: 1
-        _SceneProperties: 0
-        _PrimaryActor: 3
-        _LinkedActors: 3
-        _ActorCollisions: 1
-        _InputValue: 0
-        _InputRange: {x: 0, y: 1}
-        _AdjustMultiplier: 1
-        _OnNewValue: 0
-        _PreSmoothValue: 0
-        _Smoothing: 0.2
-        _InputLimiter: 0
-        _FlipOutput: 0
-        _OutputValue: 0
-      _ModulationAmount: 0.5
-      _ModulationExponent: 1
-      _Idle: 0
-      _Noise:
-        _Amount: 0
-        _Speed: 1
-        _Perlin: 0
-      _Min: 0
-      _Max: 2
-    _Playhead:
-      _ModulationSource:
-        _ValueSource: 1
-        _SceneProperties: 5
-        _PrimaryActor: 3
-        _LinkedActors: 3
-        _ActorCollisions: 1
-        _InputValue: 0
-        _InputRange: {x: 0, y: 20}
-        _AdjustMultiplier: 0.01
-        _OnNewValue: 1
-        _PreSmoothValue: 0
-        _Smoothing: 0.2
-        _InputLimiter: 1
-        _FlipOutput: 0
-        _OutputValue: 0
-      _ModulationAmount: 1
-      _ModulationExponent: 1
-      _Idle: 0.7
-      _Noise:
-        _Amount: 0.824
-        _Speed: 0.0001
-        _Perlin: 1
-      _Min: 0
-      _Max: 1
-    _GrainDuration:
-      _ModulationSource:
-        _ValueSource: 1
-        _SceneProperties: 0
-        _PrimaryActor: 5
-        _LinkedActors: 3
-        _ActorCollisions: 1
-        _InputValue: 0
-        _InputRange: {x: 0, y: 1}
-        _AdjustMultiplier: 1
-        _OnNewValue: 0
-        _PreSmoothValue: 0
-        _Smoothing: 0.5
-        _InputLimiter: 0
-        _FlipOutput: 0
-        _OutputValue: 0
-      _ModulationAmount: -30
-      _ModulationExponent: 1
-      _Idle: 80
-      _Noise:
-        _Amount: 0
-        _Speed: 1
-        _Perlin: 0
-      _Min: 2
-      _Max: 500
-    _Density:
-      _ModulationSource:
-        _ValueSource: 0
-        _SceneProperties: 0
-        _PrimaryActor: 3
-        _LinkedActors: 3
-        _ActorCollisions: 1
-        _InputValue: 0
-        _InputRange: {x: 0, y: 1}
-        _AdjustMultiplier: 1
-        _OnNewValue: 0
-        _PreSmoothValue: 0
-        _Smoothing: 0.2
-        _InputLimiter: 0
-        _FlipOutput: 0
-        _OutputValue: 0
-      _ModulationAmount: 0
-      _ModulationExponent: 1
-      _Idle: 3
-      _Noise:
-        _Amount: 0
-        _Speed: 1
-        _Perlin: 0
-      _Min: 0.1
-      _Max: 10
-    _Transpose:
-      _ModulationSource:
-        _ValueSource: 0
-        _SceneProperties: 0
-        _PrimaryActor: 3
-        _LinkedActors: 3
-        _ActorCollisions: 1
-        _InputValue: 0
-        _InputRange: {x: 0, y: 1}
-        _AdjustMultiplier: 1
-        _OnNewValue: 0
-        _PreSmoothValue: 0
-        _Smoothing: 0.2
-        _InputLimiter: 0
-        _FlipOutput: 0
-        _OutputValue: 0
-      _ModulationAmount: 0
-      _ModulationExponent: 1
-      _Idle: 0
-      _Noise:
-        _Amount: 0.01
-        _Speed: 2
-        _Perlin: 1
-      _Min: -3
-      _Max: 3
+  _VolumeIdle: 0
+  _VolumeModulation:
+    _ValueSource: 0
+    _SceneProperties: 0
+    _PrimaryActor: 3
+    _LinkedActors: 3
+    _ActorCollisions: 0
+    _InputValue: 0
+    _InputRange: {x: 0, y: 1}
+    _AdjustMultiplier: 1
+    _OnNewValue: 0
+    _PreSmoothValue: 0
+    _Smoothing: 0.2
+    _LimiterMode: 0
+    _ModulationExponent: 1
+    _ModulationAmount: 0
+    _Result: 0
+  _VolumeNoise:
+    _Influence: 0
+    _Multiplier: 0.1
+    _Speed: 1
+    _Perlin: 0
+  _PlayheadStartPosition: {x: 0.25, y: 0.75}
+  _PlayheadIdle: 0.5
+  _PlayheadModulation:
+    _ValueSource: 0
+    _SceneProperties: 0
+    _PrimaryActor: 3
+    _LinkedActors: 3
+    _ActorCollisions: 0
+    _InputValue: 0
+    _InputRange: {x: 0, y: 1}
+    _AdjustMultiplier: 1
+    _OnNewValue: 0
+    _PreSmoothValue: 0
+    _Smoothing: 0.2
+    _LimiterMode: 0
+    _ModulationExponent: 1
+    _ModulationAmount: 0
+    _Result: 0
+  _PlayheadNoise:
+    _Influence: 0
+    _Multiplier: 0.1
+    _Speed: 1
+    _Perlin: 0
+  _DurationIdle: 80
+  _DurationModulation:
+    _ValueSource: 0
+    _SceneProperties: 0
+    _PrimaryActor: 3
+    _LinkedActors: 3
+    _ActorCollisions: 0
+    _InputValue: 0
+    _InputRange: {x: 0, y: 1}
+    _AdjustMultiplier: 1
+    _OnNewValue: 0
+    _PreSmoothValue: 0
+    _Smoothing: 0.2
+    _LimiterMode: 0
+    _ModulationExponent: 1
+    _ModulationAmount: 0
+    _Result: 0
+  _DurationNoise:
+    _Influence: 0
+    _Multiplier: 0.1
+    _Speed: 1
+    _Perlin: 0
+  _DensityIdle: 3
+  _DensityModulation:
+    _ValueSource: 0
+    _SceneProperties: 0
+    _PrimaryActor: 3
+    _LinkedActors: 3
+    _ActorCollisions: 0
+    _InputValue: 0
+    _InputRange: {x: 0, y: 1}
+    _AdjustMultiplier: 1
+    _OnNewValue: 0
+    _PreSmoothValue: 0
+    _Smoothing: 0.2
+    _LimiterMode: 0
+    _ModulationExponent: 1
+    _ModulationAmount: 0
+    _Result: 0
+  _DensityNoise:
+    _Influence: 0
+    _Multiplier: 0.1
+    _Speed: 1
+    _Perlin: 0
+  _TransposeIdle: 0
+  _TransposeModulation:
+    _ValueSource: 0
+    _SceneProperties: 0
+    _PrimaryActor: 3
+    _LinkedActors: 3
+    _ActorCollisions: 0
+    _InputValue: 0
+    _InputRange: {x: 0, y: 1}
+    _AdjustMultiplier: 1
+    _OnNewValue: 0
+    _PreSmoothValue: 0
+    _Smoothing: 0.2
+    _LimiterMode: 0
+    _ModulationExponent: 1
+    _ModulationAmount: 0
+    _Result: 0
+  _TransposeNoise:
+    _Influence: 0
+    _Multiplier: 0.1
+    _Speed: 1
+    _Perlin: 0
 --- !u!1 &1869322150686150806
 GameObject:
   m_ObjectHideFlags: 0
@@ -564,237 +460,133 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: ae83aa2f25cab0049b0b46e068f56707, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  _EntityType: 0
-  _EntityIndex: 2147483647
-  _EntityInitialised: 0
-  _ManagerInitialised: 0
+  _AudioAsset: {fileID: 11400000, guid: c2e90c6a423100842b44708931e7e298, type: 2}
   _Host: {fileID: 6617646643115203077}
   _EmitterType: 0
   _PlaybackCondition: 1
-  _AudioAsset: {fileID: 11400000, guid: c2e90c6a423100842b44708931e7e298, type: 2}
   _VolumeAdjust: 0.5
   _DistanceAttenuationFactor: 0.4
   _AgeFadeout: 0.9
   _PingPongGrainPlayheads: 1
-  _ColliderRigidityVolumeScale: 0
-  _ModulationInputs:
-  - _ValueSource: 1
-    _SceneProperties: 0
-    _PrimaryActor: 3
-    _LinkedActors: 3
-    _ActorCollisions: 1
-    _InputValue: 0
-    _InputRange: {x: 0, y: 1}
-    _AdjustMultiplier: 1
-    _OnNewValue: 0
-    _PreSmoothValue: 0
-    _Smoothing: 0.2
-    _InputLimiter: 0
-    _FlipOutput: 0
-    _OutputValue: 0
-  - _ValueSource: 1
-    _SceneProperties: 0
-    _PrimaryActor: 3
-    _LinkedActors: 3
-    _ActorCollisions: 1
-    _InputValue: 0
-    _InputRange: {x: 0, y: 1}
-    _AdjustMultiplier: 1
-    _OnNewValue: 0
-    _PreSmoothValue: 0
-    _Smoothing: 0.2
-    _InputLimiter: 0
-    _FlipOutput: 0
-    _OutputValue: 0
-  - _ValueSource: 1
-    _SceneProperties: 0
-    _PrimaryActor: 3
-    _LinkedActors: 3
-    _ActorCollisions: 1
-    _InputValue: 0
-    _InputRange: {x: 0, y: 1}
-    _AdjustMultiplier: 1
-    _OnNewValue: 0
-    _PreSmoothValue: 0
-    _Smoothing: 0.2
-    _InputLimiter: 0
-    _FlipOutput: 0
-    _OutputValue: 0
-  - _ValueSource: 1
-    _SceneProperties: 0
-    _PrimaryActor: 3
-    _LinkedActors: 3
-    _ActorCollisions: 1
-    _InputValue: 0
-    _InputRange: {x: 0, y: 1}
-    _AdjustMultiplier: 1
-    _OnNewValue: 0
-    _PreSmoothValue: 0
-    _Smoothing: 0.2
-    _InputLimiter: 0
-    _FlipOutput: 0
-    _OutputValue: 0
-  - _ValueSource: 1
-    _SceneProperties: 0
-    _PrimaryActor: 3
-    _LinkedActors: 3
-    _ActorCollisions: 1
-    _InputValue: 0
-    _InputRange: {x: 0, y: 1}
-    _AdjustMultiplier: 1
-    _OnNewValue: 0
-    _PreSmoothValue: 0
-    _Smoothing: 0.2
-    _InputLimiter: 0
-    _FlipOutput: 0
-    _OutputValue: 0
-  - _ValueSource: 1
-    _SceneProperties: 0
-    _PrimaryActor: 3
-    _LinkedActors: 3
-    _ActorCollisions: 1
-    _InputValue: 0
-    _InputRange: {x: 0, y: 1}
-    _AdjustMultiplier: 1
-    _OnNewValue: 0
-    _PreSmoothValue: 0
-    _Smoothing: 0.2
-    _InputLimiter: 0
-    _FlipOutput: 0
-    _OutputValue: 0
+  _CollisionRigidityScaleVolume: 0
   _DSPChainParams: []
   _IsPlaying: 1
   _AdjustedDistance: 0
   _DistanceAmplitude: 0
-  _ContactSurfaceAttenuation: 1
+  _ColliderRigidityVolume: 1
   _LastTriggeredAt: 0
   _LastSampleIndex: 0
-  _Properties:
-    _Volume:
-      _ModulationSource:
-        _ValueSource: 1
-        _SceneProperties: 0
-        _PrimaryActor: 7
-        _LinkedActors: 3
-        _ActorCollisions: 1
-        _InputValue: 0
-        _InputRange: {x: 0, y: 10}
-        _AdjustMultiplier: 1
-        _OnNewValue: 0
-        _PreSmoothValue: 0
-        _Smoothing: 0.2
-        _InputLimiter: 0
-        _FlipOutput: 0
-        _OutputValue: 0
-      _ModulationAmount: 0.5
-      _ModulationExponent: 1
-      _Idle: 1
-      _Noise:
-        _Amount: 0
-        _Speed: 1
-        _Perlin: 0
-      _Min: 0
-      _Max: 2
-    _Playhead:
-      _ModulationSource:
-        _ValueSource: 1
-        _SceneProperties: 0
-        _PrimaryActor: 3
-        _LinkedActors: 3
-        _ActorCollisions: 1
-        _InputValue: 0
-        _InputRange: {x: 0, y: 1}
-        _AdjustMultiplier: 1
-        _OnNewValue: 0
-        _PreSmoothValue: 0
-        _Smoothing: 0.2
-        _InputLimiter: 1
-        _FlipOutput: 0
-        _OutputValue: 0
-      _ModulationAmount: 0
-      _ModulationExponent: 1
-      _Idle: 0.352
-      _Noise:
-        _Amount: 0.1
-        _Speed: 0.5
-        _Perlin: 1
-      _Min: 0
-      _Max: 1
-    _GrainDuration:
-      _ModulationSource:
-        _ValueSource: 1
-        _SceneProperties: 0
-        _PrimaryActor: 3
-        _LinkedActors: 3
-        _ActorCollisions: 1
-        _InputValue: 0
-        _InputRange: {x: 0, y: 15}
-        _AdjustMultiplier: 1
-        _OnNewValue: 0
-        _PreSmoothValue: 0
-        _Smoothing: 0.2
-        _InputLimiter: 0
-        _FlipOutput: 0
-        _OutputValue: 0
-      _ModulationAmount: -30
-      _ModulationExponent: 1
-      _Idle: 100
-      _Noise:
-        _Amount: 0.05
-        _Speed: 2
-        _Perlin: 1
-      _Min: 2
-      _Max: 500
-    _Density:
-      _ModulationSource:
-        _ValueSource: 0
-        _SceneProperties: 0
-        _PrimaryActor: 3
-        _LinkedActors: 3
-        _ActorCollisions: 1
-        _InputValue: 0
-        _InputRange: {x: 0, y: 1}
-        _AdjustMultiplier: 1
-        _OnNewValue: 0
-        _PreSmoothValue: 0
-        _Smoothing: 0.2
-        _InputLimiter: 0
-        _FlipOutput: 0
-        _OutputValue: 0
-      _ModulationAmount: 0
-      _ModulationExponent: 1
-      _Idle: 3
-      _Noise:
-        _Amount: 0
-        _Speed: 1
-        _Perlin: 0
-      _Min: 0.1
-      _Max: 10
-    _Transpose:
-      _ModulationSource:
-        _ValueSource: 1
-        _SceneProperties: 0
-        _PrimaryActor: 3
-        _LinkedActors: 3
-        _ActorCollisions: 1
-        _InputValue: 0
-        _InputRange: {x: 0, y: 15}
-        _AdjustMultiplier: 1
-        _OnNewValue: 0
-        _PreSmoothValue: 0
-        _Smoothing: 0.2
-        _InputLimiter: 0
-        _FlipOutput: 0
-        _OutputValue: 0
-      _ModulationAmount: 0.2
-      _ModulationExponent: 1
-      _Idle: 0
-      _Noise:
-        _Amount: 0.01
-        _Speed: 0.2
-        _Perlin: 1
-      _Min: -3
-      _Max: 3
+  _VolumeIdle: 0
+  _VolumeModulation:
+    _ValueSource: 0
+    _SceneProperties: 0
+    _PrimaryActor: 3
+    _LinkedActors: 3
+    _ActorCollisions: 0
+    _InputValue: 0
+    _InputRange: {x: 0, y: 1}
+    _AdjustMultiplier: 1
+    _OnNewValue: 0
+    _PreSmoothValue: 0
+    _Smoothing: 0.2
+    _LimiterMode: 0
+    _ModulationExponent: 1
+    _ModulationAmount: 0
+    _Result: 0
+  _VolumeNoise:
+    _Influence: 0
+    _Multiplier: 0.1
+    _Speed: 1
+    _Perlin: 0
+  _PlayheadStartPosition: {x: 0.25, y: 0.75}
+  _PlayheadIdle: 0.5
+  _PlayheadModulation:
+    _ValueSource: 0
+    _SceneProperties: 0
+    _PrimaryActor: 3
+    _LinkedActors: 3
+    _ActorCollisions: 0
+    _InputValue: 0
+    _InputRange: {x: 0, y: 1}
+    _AdjustMultiplier: 1
+    _OnNewValue: 0
+    _PreSmoothValue: 0
+    _Smoothing: 0.2
+    _LimiterMode: 0
+    _ModulationExponent: 1
+    _ModulationAmount: 0
+    _Result: 0
+  _PlayheadNoise:
+    _Influence: 0
+    _Multiplier: 0.1
+    _Speed: 1
+    _Perlin: 0
+  _DurationIdle: 80
+  _DurationModulation:
+    _ValueSource: 0
+    _SceneProperties: 0
+    _PrimaryActor: 3
+    _LinkedActors: 3
+    _ActorCollisions: 0
+    _InputValue: 0
+    _InputRange: {x: 0, y: 1}
+    _AdjustMultiplier: 1
+    _OnNewValue: 0
+    _PreSmoothValue: 0
+    _Smoothing: 0.2
+    _LimiterMode: 0
+    _ModulationExponent: 1
+    _ModulationAmount: 0
+    _Result: 0
+  _DurationNoise:
+    _Influence: 0
+    _Multiplier: 0.1
+    _Speed: 1
+    _Perlin: 0
+  _DensityIdle: 3
+  _DensityModulation:
+    _ValueSource: 0
+    _SceneProperties: 0
+    _PrimaryActor: 3
+    _LinkedActors: 3
+    _ActorCollisions: 0
+    _InputValue: 0
+    _InputRange: {x: 0, y: 1}
+    _AdjustMultiplier: 1
+    _OnNewValue: 0
+    _PreSmoothValue: 0
+    _Smoothing: 0.2
+    _LimiterMode: 0
+    _ModulationExponent: 1
+    _ModulationAmount: 0
+    _Result: 0
+  _DensityNoise:
+    _Influence: 0
+    _Multiplier: 0.1
+    _Speed: 1
+    _Perlin: 0
+  _TransposeIdle: 0
+  _TransposeModulation:
+    _ValueSource: 0
+    _SceneProperties: 0
+    _PrimaryActor: 3
+    _LinkedActors: 3
+    _ActorCollisions: 0
+    _InputValue: 0
+    _InputRange: {x: 0, y: 1}
+    _AdjustMultiplier: 1
+    _OnNewValue: 0
+    _PreSmoothValue: 0
+    _Smoothing: 0.2
+    _LimiterMode: 0
+    _ModulationExponent: 1
+    _ModulationAmount: 0
+    _Result: 0
+  _TransposeNoise:
+    _Influence: 0
+    _Multiplier: 0.1
+    _Speed: 1
+    _Perlin: 0
 --- !u!1 &2740575023969093836
 GameObject:
   m_ObjectHideFlags: 0
@@ -839,264 +631,155 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 82176498da827a14399bfa643052dc47, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  _EntityType: 0
-  _EntityIndex: 2147483647
-  _EntityInitialised: 0
-  _ManagerInitialised: 0
+  _AudioAsset: {fileID: 11400000, guid: 3903332cdaef3aa4691efd7750990a98, type: 2}
   _Host: {fileID: 6617646643115203077}
   _EmitterType: 1
   _PlaybackCondition: 1
-  _AudioAsset: {fileID: 11400000, guid: 3903332cdaef3aa4691efd7750990a98, type: 2}
   _VolumeAdjust: 0.6
   _DistanceAttenuationFactor: 0.6
   _AgeFadeout: 0.9
   _PingPongGrainPlayheads: 1
-  _ColliderRigidityVolumeScale: 0
-  _ModulationInputs:
-  - _ValueSource: 1
-    _SceneProperties: 0
-    _PrimaryActor: 3
-    _LinkedActors: 3
-    _ActorCollisions: 1
-    _InputValue: 0
-    _InputRange: {x: 0, y: 1}
-    _AdjustMultiplier: 1
-    _OnNewValue: 0
-    _PreSmoothValue: 0
-    _Smoothing: 0.2
-    _InputLimiter: 0
-    _FlipOutput: 0
-    _OutputValue: 0
-  - _ValueSource: 1
-    _SceneProperties: 0
-    _PrimaryActor: 3
-    _LinkedActors: 3
-    _ActorCollisions: 1
-    _InputValue: 0
-    _InputRange: {x: 0, y: 1}
-    _AdjustMultiplier: 1
-    _OnNewValue: 0
-    _PreSmoothValue: 0
-    _Smoothing: 0.2
-    _InputLimiter: 0
-    _FlipOutput: 0
-    _OutputValue: 0
-  - _ValueSource: 1
-    _SceneProperties: 0
-    _PrimaryActor: 3
-    _LinkedActors: 3
-    _ActorCollisions: 1
-    _InputValue: 0
-    _InputRange: {x: 0, y: 1}
-    _AdjustMultiplier: 1
-    _OnNewValue: 0
-    _PreSmoothValue: 0
-    _Smoothing: 0.2
-    _InputLimiter: 0
-    _FlipOutput: 0
-    _OutputValue: 0
-  - _ValueSource: 1
-    _SceneProperties: 0
-    _PrimaryActor: 3
-    _LinkedActors: 3
-    _ActorCollisions: 1
-    _InputValue: 0
-    _InputRange: {x: 0, y: 1}
-    _AdjustMultiplier: 1
-    _OnNewValue: 0
-    _PreSmoothValue: 0
-    _Smoothing: 0.2
-    _InputLimiter: 0
-    _FlipOutput: 0
-    _OutputValue: 0
-  - _ValueSource: 1
-    _SceneProperties: 0
-    _PrimaryActor: 3
-    _LinkedActors: 3
-    _ActorCollisions: 1
-    _InputValue: 0
-    _InputRange: {x: 0, y: 1}
-    _AdjustMultiplier: 1
-    _OnNewValue: 0
-    _PreSmoothValue: 0
-    _Smoothing: 0.2
-    _InputLimiter: 0
-    _FlipOutput: 0
-    _OutputValue: 0
-  - _ValueSource: 1
-    _SceneProperties: 0
-    _PrimaryActor: 3
-    _LinkedActors: 3
-    _ActorCollisions: 1
-    _InputValue: 0
-    _InputRange: {x: 0, y: 1}
-    _AdjustMultiplier: 1
-    _OnNewValue: 0
-    _PreSmoothValue: 0
-    _Smoothing: 0.2
-    _InputLimiter: 0
-    _FlipOutput: 0
-    _OutputValue: 0
+  _CollisionRigidityScaleVolume: 0
   _DSPChainParams: []
   _IsPlaying: 1
   _AdjustedDistance: 0
   _DistanceAmplitude: 0
-  _ContactSurfaceAttenuation: 1
+  _ColliderRigidityVolume: 1
   _LastTriggeredAt: 0
   _LastSampleIndex: 0
-  _Properties:
-    _Volume:
-      _ModulationSource:
-        _ValueSource: 3
-        _SceneProperties: 0
-        _PrimaryActor: 3
-        _LinkedActors: 3
-        _ActorCollisions: 1
-        _InputValue: 0
-        _InputRange: {x: 0, y: 1}
-        _AdjustMultiplier: 10
-        _OnNewValue: 0
-        _PreSmoothValue: 0
-        _Smoothing: 0
-        _InputLimiter: 0
-        _FlipOutput: 0
-        _OutputValue: 0
-      _ModulationAmount: 1
-      _ModulationExponent: 1
-      _Start: 0
-      _End: 0
-      _EndIgnoresModulation: 1
-      _Noise:
-        _Amount: 0
-        _HoldForBurstDuration: 0
-      _Min: 0
-      _Max: 2
-    _Playhead:
-      _ModulationSource:
-        _ValueSource: 3
-        _SceneProperties: 0
-        _PrimaryActor: 3
-        _LinkedActors: 3
-        _ActorCollisions: 1
-        _InputValue: 0
-        _InputRange: {x: 0, y: 1}
-        _AdjustMultiplier: 10
-        _OnNewValue: 0
-        _PreSmoothValue: 0
-        _Smoothing: 0
-        _InputLimiter: 0
-        _FlipOutput: 0
-        _OutputValue: 0
-      _ModulationAmount: -0.1
-      _ModulationExponent: 1
-      _Start: 0.1
-      _End: 0.583
-      _StartIgnoresModulation: 0
-      _Noise:
-        _Amount: 0
-        _HoldForBurstDuration: 0
-      _Min: 0
-      _Max: 1
-    _BurstDuration:
-      _ModulationSource:
-        _ValueSource: 3
-        _SceneProperties: 0
-        _PrimaryActor: 3
-        _LinkedActors: 3
-        _ActorCollisions: 1
-        _InputValue: 0
-        _InputRange: {x: 0, y: 10}
-        _AdjustMultiplier: 1
-        _OnNewValue: 0
-        _PreSmoothValue: 0
-        _Smoothing: 0
-        _InputLimiter: 0
-        _FlipOutput: 0
-        _OutputValue: 0
-      _ModulationAmount: 100
-      _ModulationExponent: 2
-      _Default: 100
-      _Noise:
-        _Amount: 0.02
-        _HoldForBurstDuration: 0
-      _Min: 10
-      _Max: 1000
-    _GrainDuration:
-      _ModulationSource:
-        _ValueSource: 0
-        _SceneProperties: 0
-        _PrimaryActor: 3
-        _LinkedActors: 3
-        _ActorCollisions: 1
-        _InputValue: 0
-        _InputRange: {x: 0, y: 10}
-        _AdjustMultiplier: 1
-        _OnNewValue: 0
-        _PreSmoothValue: 0
-        _Smoothing: 0
-        _InputLimiter: 0
-        _FlipOutput: 0
-        _OutputValue: 0
-      _ModulationAmount: 0
-      _ModulationExponent: 1
-      _Start: 40
-      _End: 70
-      _Noise:
-        _Amount: 0.03
-        _HoldForBurstDuration: 0
-      _Min: 5
-      _Max: 500
-    _Density:
-      _ModulationSource:
-        _ValueSource: 1
-        _SceneProperties: 0
-        _PrimaryActor: 3
-        _LinkedActors: 3
-        _ActorCollisions: 1
-        _InputValue: 0
-        _InputRange: {x: 0, y: 1}
-        _AdjustMultiplier: 1
-        _OnNewValue: 0
-        _PreSmoothValue: 0
-        _Smoothing: 0.2
-        _InputLimiter: 0
-        _FlipOutput: 0
-        _OutputValue: 0
-      _ModulationAmount: 0
-      _ModulationExponent: 1
-      _Start: 3
-      _End: 3
-      _Noise:
-        _Amount: 0
-        _HoldForBurstDuration: 0
-      _Min: 0.1
-      _Max: 10
-    _Transpose:
-      _ModulationSource:
-        _ValueSource: 0
-        _SceneProperties: 0
-        _PrimaryActor: 3
-        _LinkedActors: 3
-        _ActorCollisions: 1
-        _InputValue: 0
-        _InputRange: {x: 0, y: 1}
-        _AdjustMultiplier: 1
-        _OnNewValue: 0
-        _PreSmoothValue: 0
-        _Smoothing: 0.2
-        _InputLimiter: 0
-        _FlipOutput: 0
-        _OutputValue: 0
-      _ModulationAmount: 0
-      _ModulationExponent: 1
-      _Start: 1
-      _End: 0
-      _EndIgnoresModulation: 1
-      _Noise:
-        _Amount: 0.01
-        _HoldForBurstDuration: 1
-      _Min: -3
-      _Max: 3
+  _VolumeModulation:
+    _ValueSource: 0
+    _SceneProperties: 0
+    _PrimaryActor: 3
+    _LinkedActors: 3
+    _ActorCollisions: 0
+    _InputValue: 0
+    _InputRange: {x: 0, y: 1}
+    _AdjustMultiplier: 1
+    _OnNewValue: 0
+    _PreSmoothValue: 0
+    _Smoothing: 0.2
+    _LimiterMode: 0
+    _ModulationExponent: 1
+    _ModulationAmount: 0
+    _Result: 0
+  _VolumeNoise:
+    _Influence: 0
+    _Multiplier: 0.1
+    _HoldForBurstDuration: 0
+  _LengthDefault: 200
+  _LengthModulation:
+    _ValueSource: 0
+    _SceneProperties: 0
+    _PrimaryActor: 3
+    _LinkedActors: 3
+    _ActorCollisions: 0
+    _InputValue: 0
+    _InputRange: {x: 0, y: 1}
+    _AdjustMultiplier: 1
+    _OnNewValue: 0
+    _PreSmoothValue: 0
+    _Smoothing: 0.2
+    _LimiterMode: 0
+    _ModulationExponent: 1
+    _ModulationAmount: 0
+    _Result: 0
+  _LengthNoise:
+    _Influence: 0
+    _Multiplier: 0.1
+    _HoldForBurstDuration: 0
+  _PlayheadPath: {x: 0, y: 0.5}
+  _PlayheadFixedStart: 1
+  _PlayheadFixedEnd: 0
+  _PlayheadModulation:
+    _ValueSource: 0
+    _SceneProperties: 0
+    _PrimaryActor: 3
+    _LinkedActors: 3
+    _ActorCollisions: 0
+    _InputValue: 0
+    _InputRange: {x: 0, y: 1}
+    _AdjustMultiplier: 1
+    _OnNewValue: 0
+    _PreSmoothValue: 0
+    _Smoothing: 0.2
+    _LimiterMode: 0
+    _ModulationExponent: 1
+    _ModulationAmount: 0
+    _Result: 0
+  _PlayheadNoise:
+    _Influence: 0
+    _Multiplier: 0.1
+    _HoldForBurstDuration: 0
+  _DurationPath: {x: 80, y: 120}
+  _DurationFixedStart: 0
+  _DurationFixedEnd: 1
+  _DurationModulation:
+    _ValueSource: 0
+    _SceneProperties: 0
+    _PrimaryActor: 3
+    _LinkedActors: 3
+    _ActorCollisions: 0
+    _InputValue: 0
+    _InputRange: {x: 0, y: 1}
+    _AdjustMultiplier: 1
+    _OnNewValue: 0
+    _PreSmoothValue: 0
+    _Smoothing: 0.2
+    _LimiterMode: 0
+    _ModulationExponent: 1
+    _ModulationAmount: 0
+    _Result: 0
+  _DurationNoise:
+    _Influence: 0
+    _Multiplier: 0.1
+    _HoldForBurstDuration: 0
+  _DensityPath: {x: 2, y: 3}
+  _DensityFixedStart: 0
+  _DensityFixedEnd: 0
+  _DensityModulation:
+    _ValueSource: 0
+    _SceneProperties: 0
+    _PrimaryActor: 3
+    _LinkedActors: 3
+    _ActorCollisions: 0
+    _InputValue: 0
+    _InputRange: {x: 0, y: 1}
+    _AdjustMultiplier: 1
+    _OnNewValue: 0
+    _PreSmoothValue: 0
+    _Smoothing: 0.2
+    _LimiterMode: 0
+    _ModulationExponent: 1
+    _ModulationAmount: 0
+    _Result: 0
+  _DensityNoise:
+    _Influence: 0
+    _Multiplier: 0.1
+    _HoldForBurstDuration: 0
+  _TransposePath: {x: 0, y: 0}
+  _TransposeFixedStart: 0
+  _TransposeFixedEnd: 0
+  _TransposeModulation:
+    _ValueSource: 0
+    _SceneProperties: 0
+    _PrimaryActor: 3
+    _LinkedActors: 3
+    _ActorCollisions: 0
+    _InputValue: 0
+    _InputRange: {x: 0, y: 1}
+    _AdjustMultiplier: 1
+    _OnNewValue: 0
+    _PreSmoothValue: 0
+    _Smoothing: 0.2
+    _LimiterMode: 0
+    _ModulationExponent: 1
+    _ModulationAmount: 0
+    _Result: 0
+  _TransposeNoise:
+    _Influence: 0
+    _Multiplier: 0.1
+    _HoldForBurstDuration: 0
 --- !u!1 &9068927071162158580
 GameObject:
   m_ObjectHideFlags: 0
@@ -1141,14 +824,13 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: f1dc6aac3ee08b846b7c9c82fe36fcc2, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  _EntityType: 0
-  _EntityIndex: 2147483647
-  _EntityInitialised: 0
-  _ManagerInitialised: 0
   _SpeakerTarget: {fileID: 0}
   _SpeakerTransform: {fileID: 0}
+  _AttachmentRenderer: {fileID: 0}
   _Spawner: {fileID: 0}
   _SpawnLife: {fileID: 0}
+  _LocalTransform: {fileID: 0}
+  _RemoteTransform: {fileID: 0}
   _CollisionPipeComponent: {fileID: 0}
   _SelfRigidity: 0.5
   _EaseCollidingRigidity: 0.5

--- a/Assets/_Project/Scenes/PlaneWaver_Demo.unity
+++ b/Assets/_Project/Scenes/PlaneWaver_Demo.unity
@@ -38,7 +38,7 @@ RenderSettings:
   m_ReflectionIntensity: 1
   m_CustomReflection: {fileID: 0}
   m_Sun: {fileID: 2138677392}
-  m_IndirectSpecularColor: {r: 440.66986, g: 406.037, b: 387.5498, a: 1}
+  m_IndirectSpecularColor: {r: 473.24658, g: 447.8108, b: 462.25195, a: 1}
   m_UseRadianceAmbientProbe: 0
 --- !u!157 &3
 LightmapSettings:
@@ -481,7 +481,7 @@ MonoBehaviour:
   _RandomiseSpawnPrefab: 0
   _SpawnablePrefabs: []
   _ActiveObjects: []
-  _SpawnablesAllocated: 30
+  _SpawnablesAllocated: 20
   _SpawnPeriodSeconds: 0.1
   _SpawnCondition: 1
   _SpawnDelaySeconds: 2
@@ -660,8 +660,8 @@ MonoBehaviour:
     _TukeyHeight: 0.5
     _GaussianSigma: 0
     _LinearInOutFade: 0.01
-  _SpeakersAllocated: 20
-  _SpeakerAllocationPeriod: 0.2
+  _SpeakersAllocated: 4
+  _SpeakerAllocationPeriod: 0.1
   _SpeakerPrefab: {fileID: 2519325204652697373, guid: 6844ced249a80dd4584a457e05fa1c66,
     type: 3}
   _SpeakerParentTransform: {fileID: 1810087969}

--- a/Assets/_Project/Scenes/PlaneWaver_Demo.unity
+++ b/Assets/_Project/Scenes/PlaneWaver_Demo.unity
@@ -38,7 +38,7 @@ RenderSettings:
   m_ReflectionIntensity: 1
   m_CustomReflection: {fileID: 0}
   m_Sun: {fileID: 2138677392}
-  m_IndirectSpecularColor: {r: 439.45654, g: 405.063, b: 388.1543, a: 1}
+  m_IndirectSpecularColor: {r: 440.66986, g: 406.037, b: 387.5498, a: 1}
   m_UseRadianceAmbientProbe: 0
 --- !u!157 &3
 LightmapSettings:
@@ -481,10 +481,10 @@ MonoBehaviour:
   _RandomiseSpawnPrefab: 0
   _SpawnablePrefabs: []
   _ActiveObjects: []
-  _SpawnCondition: 1
-  _SecondsBeforeSpawning: 5
-  _SpawnablesAllocated: 10
+  _SpawnablesAllocated: 30
   _SpawnPeriodSeconds: 0.1
+  _SpawnCondition: 1
+  _SpawnDelaySeconds: 2
   _AutoSpawn: 1
   _AutoRemove: 1
   _EjectionDirection: {x: 0, y: -1, z: 0}
@@ -669,7 +669,7 @@ MonoBehaviour:
   _SpeakerGrainArraySize: 100
   _SpeakerBusyLoadLimit: 0.5
   _SpeakerAttachArcDegrees: 20
-  _SpeakerTrackingSpeed: 20
+  _SpeakerTrackingSpeed: 10
   _SpeakerLingerTime: 300
   _StatsValuesText: {fileID: 1931825995}
   _StatsValuesPeakText: {fileID: 475395361}
@@ -3689,10 +3689,10 @@ MonoBehaviour:
   _RandomiseSpawnPrefab: 0
   _SpawnablePrefabs: []
   _ActiveObjects: []
-  _SpawnCondition: 1
-  _SecondsBeforeSpawning: 2
   _SpawnablesAllocated: 20
   _SpawnPeriodSeconds: 0.2
+  _SpawnCondition: 1
+  _SpawnDelaySeconds: 2
   _AutoSpawn: 1
   _AutoRemove: 1
   _EjectionDirection: {x: 0, y: 0, z: 0}
@@ -5287,13 +5287,13 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 7a68c43fe1f2a47cfa234b5eeaa98012, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  m_Intensity: 40000
+  m_Intensity: 0
   m_EnableSpotReflector: 1
   m_LuxAtDistance: 1
   m_InnerSpotPercent: 0
   m_SpotIESCutoffPercent: 100
   m_LightDimmer: 1
-  m_VolumetricDimmer: 16
+  m_VolumetricDimmer: 4
   m_LightUnit: 0
   m_FadeDistance: 10000
   m_VolumetricFadeDistance: 10
@@ -5409,7 +5409,7 @@ Light:
   m_Type: 2
   m_Shape: 0
   m_Color: {r: 0.87058824, g: 0.6901961, b: 0.37254903, a: 1}
-  m_Intensity: 3183.0989
+  m_Intensity: 0
   m_Range: 3
   m_SpotAngle: 30
   m_InnerSpotAngle: 21.80208
@@ -7531,10 +7531,10 @@ MonoBehaviour:
   _RandomiseSpawnPrefab: 0
   _SpawnablePrefabs: []
   _ActiveObjects: []
-  _SpawnCondition: 1
-  _SecondsBeforeSpawning: 2
   _SpawnablesAllocated: 20
   _SpawnPeriodSeconds: 0.2
+  _SpawnCondition: 1
+  _SpawnDelaySeconds: 2
   _AutoSpawn: 1
   _AutoRemove: 1
   _EjectionDirection: {x: 0, y: 0, z: 0}
@@ -11283,10 +11283,34 @@ MonoBehaviour:
       m_Calls: []
   m_SelectEntered:
     m_PersistentCalls:
-      m_Calls: []
+      m_Calls:
+      - m_Target: {fileID: 905535404}
+        m_TargetAssemblyTypeName: UnityEngine.Light, UnityEngine
+        m_MethodName: set_intensity
+        m_Mode: 4
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 5000
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 0
   m_SelectExited:
     m_PersistentCalls:
-      m_Calls: []
+      m_Calls:
+      - m_Target: {fileID: 905535404}
+        m_TargetAssemblyTypeName: UnityEngine.Light, UnityEngine
+        m_MethodName: set_intensity
+        m_Mode: 4
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 0
   m_Activated:
     m_PersistentCalls:
       m_Calls: []
@@ -11327,7 +11351,7 @@ MonoBehaviour:
   m_MatchAttachPosition: 1
   m_MatchAttachRotation: 1
   m_SnapToColliderVolume: 1
-  m_AttachEaseInTime: 0.4
+  m_AttachEaseInTime: 1
   m_MovementType: 0
   m_VelocityDamping: 0.9
   m_VelocityScale: 0.25
@@ -12982,10 +13006,10 @@ MonoBehaviour:
   _RandomiseSpawnPrefab: 0
   _SpawnablePrefabs: []
   _ActiveObjects: []
-  _SpawnCondition: 1
-  _SecondsBeforeSpawning: 2
   _SpawnablesAllocated: 1
   _SpawnPeriodSeconds: 0.1
+  _SpawnCondition: 1
+  _SpawnDelaySeconds: 2
   _AutoSpawn: 1
   _AutoRemove: 1
   _EjectionDirection: {x: 0, y: 0, z: 0}

--- a/Assets/_Project/Scenes/PlaneWaver_Demo.unity
+++ b/Assets/_Project/Scenes/PlaneWaver_Demo.unity
@@ -38,7 +38,7 @@ RenderSettings:
   m_ReflectionIntensity: 1
   m_CustomReflection: {fileID: 0}
   m_Sun: {fileID: 2138677392}
-  m_IndirectSpecularColor: {r: 442.17883, g: 407.29297, b: 386.5044, a: 1}
+  m_IndirectSpecularColor: {r: 439.45654, g: 405.063, b: 388.1543, a: 1}
   m_UseRadianceAmbientProbe: 0
 --- !u!157 &3
 LightmapSettings:
@@ -442,7 +442,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 0
+  m_IsActive: 1
 --- !u!4 &22275141
 Transform:
   m_ObjectHideFlags: 0
@@ -451,7 +451,7 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 22275140}
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0, y: 0.5, z: 1.5}
+  m_LocalPosition: {x: 0, y: 2, z: 3}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children:
@@ -481,28 +481,29 @@ MonoBehaviour:
   _RandomiseSpawnPrefab: 0
   _SpawnablePrefabs: []
   _ActiveObjects: []
-  _WaitBeforeSpawning: 4
-  _SpawnablesAllocated: 1
-  _SpawnPeriodSeconds: 1
+  _SpawnCondition: 1
+  _SecondsBeforeSpawning: 5
+  _SpawnablesAllocated: 10
+  _SpawnPeriodSeconds: 0.1
   _AutoSpawn: 1
   _AutoRemove: 1
+  _EjectionDirection: {x: 0, y: -1, z: 0}
+  _EjectionDirectionVariance: 0.5
+  _EjectionRadiusRange: {x: 0.5, y: 0.5}
+  _EjectionSpeedRange: {x: 5, y: 10}
   _DestroyOnAllCollisions: 0
-  _BoundingAreaType: 3
+  _BoundingAreaType: 1
   _BoundingCollider: {fileID: 0}
   _BoundingRadius: 30
   _UseSpawnDuration: 1
-  _SpawnObjectDuration: {x: 2, y: 2}
-  _EmissiveFlashEvent: 1
+  _SpawnObjectDuration: {x: 6, y: 8}
+  _AllowSiblingSurfaceContact: 1
+  _AllowSiblingCollisionTrigger: 1
+  _EmissiveFlashTrigger: 1
   _EmissiveBrightness: {x: 0, y: 10}
   _EmissiveFlashFade: 0.5
   _ControllerRenderers:
   - {fileID: 1716587906}
-  _EjectionDirection: {x: 0, y: 0, z: -1}
-  _EjectionDirectionVariance: 0.1
-  _EjectionRadiusRange: {x: 1, y: 1}
-  _EjectionSpeedRange: {x: 22.733025, y: 40.733025}
-  _AllowSiblingSurfaceContact: 1
-  _AllowSiblingCollisionBurst: 1
 --- !u!1 &24721011
 GameObject:
   m_ObjectHideFlags: 0
@@ -512,8 +513,8 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 24721014}
-  - component: {fileID: 24721013}
   - component: {fileID: 24721012}
+  - component: {fileID: 24721015}
   m_Layer: 19
   m_Name: GrainSynth
   m_TagString: Untagged
@@ -617,50 +618,6 @@ AudioSource:
     m_PreInfinity: 2
     m_PostInfinity: 2
     m_RotationOrder: 4
---- !u!114 &24721013
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 24721011}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 575024e13d07ce244a554537f81bdf43, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  _ListenerRadius: 35
-  _QueueDurationMS: 30
-  _DelayPercentLastFrame: 12
-  _DiscardGrainsOlderThanMS: 50
-  _BurstStartOffsetRangeMS: 8
-  _BurstDebounceDurationMS: 50
-  _GrainEnvelope:
-    _WindowFunction: 4
-    _EnvelopeSize: 512
-    _TukeyHeight: 0.65
-    _GaussianSigma: 0.5
-    _LinearInOutFade: 0.1
-  _SpeakersAllocated: 10
-  _SpeakerAllocationPeriod: 0.2
-  _SpeakerPrefab: {fileID: 2519325204652697373, guid: 6844ced249a80dd4584a457e05fa1c66,
-    type: 3}
-  _SpeakerParentTransform: {fileID: 1810087969}
-  _SpeakerPoolingPosition: {x: 0, y: -100, z: 0}
-  _SpeakerGrainArraySize: 100
-  _SpeakerBusyLoadLimit: 0.8
-  _SpeakerAttachArcDegrees: 12
-  _SpeakerTrackingSpeed: 30
-  _SpeakerLingerTime: 300
-  _StatsValuesText: {fileID: 1931825995}
-  _StatsValuesPeakText: {fileID: 475395361}
-  _DrawAttachmentLines: 1
-  _AttachmentLineMat: {fileID: 2100000, guid: 96663e35961d281459bbcc36e6b84157, type: 2}
-  _AttachmentLineWidth: 0.01
-  _OnlyTriggerMostRigidSurface: 1
-  _Hosts: []
-  _Emitters: []
-  _Speakers: []
 --- !u!4 &24721014
 Transform:
   m_ObjectHideFlags: 0
@@ -675,11 +632,54 @@ Transform:
   m_Children:
   - {fileID: 1109771458}
   - {fileID: 1074502017}
-  - {fileID: 632517003}
   - {fileID: 1810087969}
   m_Father: {fileID: 0}
   m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &24721015
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 24721011}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 71a200e41e1c3894daaaa6c184452e30, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _ListenerRadius: 20
+  _QueueDurationMS: 22
+  _DelayPercentLastFrame: 10
+  _DiscardGrainsOlderThanMS: 30
+  _BurstStartOffsetRangeMS: 8
+  _BurstDebounceDurationMS: 25
+  _GrainEnvelope:
+    _WindowFunction: 3
+    _EnvelopeSize: 512
+    _TukeyHeight: 0.5
+    _GaussianSigma: 0
+    _LinearInOutFade: 0.01
+  _SpeakersAllocated: 20
+  _SpeakerAllocationPeriod: 0.2
+  _SpeakerPrefab: {fileID: 2519325204652697373, guid: 6844ced249a80dd4584a457e05fa1c66,
+    type: 3}
+  _SpeakerParentTransform: {fileID: 1810087969}
+  _SpeakerPoolingPosition: {x: 0, y: -20, z: 0}
+  _SpeakerGrainArraySize: 100
+  _SpeakerBusyLoadLimit: 0.5
+  _SpeakerAttachArcDegrees: 20
+  _SpeakerTrackingSpeed: 20
+  _SpeakerLingerTime: 300
+  _StatsValuesText: {fileID: 1931825995}
+  _StatsValuesPeakText: {fileID: 475395361}
+  _DrawAttachmentLines: 1
+  _AttachmentLineMat: {fileID: 2100000, guid: 96663e35961d281459bbcc36e6b84157, type: 2}
+  _AttachmentLineWidth: 0.002
+  _OnlyTriggerMostRigidSurface: 1
+  _Hosts: []
+  _Emitters: []
+  _Speakers: []
 --- !u!4 &49154439 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 3855671869938862446, guid: 02ec51453b34a444bb3fa1cd193668aa,
@@ -3631,7 +3631,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 1
+  m_IsActive: 0
 --- !u!4 &580930030
 Transform:
   m_ObjectHideFlags: 0
@@ -3689,28 +3689,29 @@ MonoBehaviour:
   _RandomiseSpawnPrefab: 0
   _SpawnablePrefabs: []
   _ActiveObjects: []
-  _WaitBeforeSpawning: 1
+  _SpawnCondition: 1
+  _SecondsBeforeSpawning: 2
   _SpawnablesAllocated: 20
   _SpawnPeriodSeconds: 0.2
   _AutoSpawn: 1
   _AutoRemove: 1
+  _EjectionDirection: {x: 0, y: 0, z: 0}
+  _EjectionDirectionVariance: 1
+  _EjectionRadiusRange: {x: 0, y: 0}
+  _EjectionSpeedRange: {x: 5, y: 10}
   _DestroyOnAllCollisions: 0
   _BoundingAreaType: 3
   _BoundingCollider: {fileID: 646365376}
   _BoundingRadius: 30
   _UseSpawnDuration: 1
   _SpawnObjectDuration: {x: 4, y: 4}
-  _EmissiveFlashEvent: 1
+  _AllowSiblingSurfaceContact: 1
+  _AllowSiblingCollisionTrigger: 1
+  _EmissiveFlashTrigger: 1
   _EmissiveBrightness: {x: -2, y: 10}
   _EmissiveFlashFade: 0.5
   _ControllerRenderers:
   - {fileID: 2055433414}
-  _EjectionDirection: {x: 0, y: 0, z: 0}
-  _EjectionDirectionVariance: 1
-  _EjectionRadiusRange: {x: 0, y: 0}
-  _EjectionSpeedRange: {x: 5, y: 10}
-  _AllowSiblingSurfaceContact: 1
-  _AllowSiblingCollisionBurst: 1
 --- !u!1 &614162126
 GameObject:
   m_ObjectHideFlags: 0
@@ -3905,50 +3906,6 @@ MeshFilter:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 629107664}
   m_Mesh: {fileID: 10202, guid: 0000000000000000e000000000000000, type: 0}
---- !u!1 &632517002
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 632517003}
-  - component: {fileID: 632517004}
-  m_Layer: 0
-  m_Name: _BlankInput
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &632517003
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 632517002}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 24721014}
-  m_RootOrder: 2
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &632517004
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 632517002}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 18d85530775693343adef74410d70fd7, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!1 &646365370
 GameObject:
   m_ObjectHideFlags: 0
@@ -5451,7 +5408,7 @@ Light:
   serializedVersion: 10
   m_Type: 2
   m_Shape: 0
-  m_Color: {r: 0.5785821, g: 0.49324608, b: 0.88031507, a: 1}
+  m_Color: {r: 0.87058824, g: 0.6901961, b: 0.37254903, a: 1}
   m_Intensity: 3183.0989
   m_Range: 3
   m_SpotAngle: 30
@@ -5494,7 +5451,7 @@ Light:
   m_Lightmapping: 4
   m_LightShadowCasterMode: 2
   m_AreaSize: {x: 1, y: 1}
-  m_BounceIntensity: 10
+  m_BounceIntensity: 0
   m_ColorTemperature: 6570
   m_UseColorTemperature: 0
   m_BoundingSphereOverride: {x: 0, y: 0, z: 0, w: 10}
@@ -7574,28 +7531,29 @@ MonoBehaviour:
   _RandomiseSpawnPrefab: 0
   _SpawnablePrefabs: []
   _ActiveObjects: []
-  _WaitBeforeSpawning: 1
+  _SpawnCondition: 1
+  _SecondsBeforeSpawning: 2
   _SpawnablesAllocated: 20
   _SpawnPeriodSeconds: 0.2
   _AutoSpawn: 1
   _AutoRemove: 1
+  _EjectionDirection: {x: 0, y: 0, z: 0}
+  _EjectionDirectionVariance: 1
+  _EjectionRadiusRange: {x: 0, y: 0.5}
+  _EjectionSpeedRange: {x: 12.261679, y: 25.421679}
   _DestroyOnAllCollisions: 0
   _BoundingAreaType: 3
   _BoundingCollider: {fileID: 0}
   _BoundingRadius: 30
   _UseSpawnDuration: 1
   _SpawnObjectDuration: {x: 4, y: 6}
-  _EmissiveFlashEvent: 1
+  _AllowSiblingSurfaceContact: 1
+  _AllowSiblingCollisionTrigger: 1
+  _EmissiveFlashTrigger: 1
   _EmissiveBrightness: {x: 0, y: 10}
   _EmissiveFlashFade: 0.5
   _ControllerRenderers:
   - {fileID: 1739783625}
-  _EjectionDirection: {x: 0, y: 0, z: 0}
-  _EjectionDirectionVariance: 1
-  _EjectionRadiusRange: {x: 0, y: 0.5}
-  _EjectionSpeedRange: {x: 12.261679, y: 25.421679}
-  _AllowSiblingSurfaceContact: 1
-  _AllowSiblingCollisionBurst: 1
 --- !u!114 &1196933172
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -10001,7 +9959,7 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1689871100}
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0, y: 1.5, z: 0.5}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children:
@@ -11243,7 +11201,7 @@ Transform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 24721014}
-  m_RootOrder: 3
+  m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1811036108
 GameObject:
@@ -13024,27 +12982,28 @@ MonoBehaviour:
   _RandomiseSpawnPrefab: 0
   _SpawnablePrefabs: []
   _ActiveObjects: []
-  _WaitBeforeSpawning: 1
+  _SpawnCondition: 1
+  _SecondsBeforeSpawning: 2
   _SpawnablesAllocated: 1
   _SpawnPeriodSeconds: 0.1
   _AutoSpawn: 1
   _AutoRemove: 1
+  _EjectionDirection: {x: 0, y: 0, z: 0}
+  _EjectionDirectionVariance: 1
+  _EjectionRadiusRange: {x: 5, y: 10}
+  _EjectionSpeedRange: {x: 5, y: 10}
   _DestroyOnAllCollisions: 0
   _BoundingAreaType: 2
   _BoundingCollider: {fileID: 0}
   _BoundingRadius: 30
   _UseSpawnDuration: 1
   _SpawnObjectDuration: {x: 5, y: 10}
-  _EmissiveFlashEvent: 1
+  _AllowSiblingSurfaceContact: 1
+  _AllowSiblingCollisionTrigger: 1
+  _EmissiveFlashTrigger: 1
   _EmissiveBrightness: {x: -10, y: 10}
   _EmissiveFlashFade: 0.5
   _ControllerRenderers: []
-  _EjectionDirection: {x: 0, y: 0, z: 0}
-  _EjectionDirectionVariance: 1
-  _EjectionRadiusRange: {x: 5, y: 10}
-  _EjectionSpeedRange: {x: 5, y: 10}
-  _AllowSiblingSurfaceContact: 1
-  _AllowSiblingCollisionBurst: 1
 --- !u!4 &331703749975080555
 Transform:
   m_ObjectHideFlags: 0

--- a/Assets/_Project/Scenes/PlaneWaver_Demo.unity
+++ b/Assets/_Project/Scenes/PlaneWaver_Demo.unity
@@ -38,7 +38,7 @@ RenderSettings:
   m_ReflectionIntensity: 1
   m_CustomReflection: {fileID: 0}
   m_Sun: {fileID: 2138677392}
-  m_IndirectSpecularColor: {r: 473.24658, g: 447.8108, b: 462.25195, a: 1}
+  m_IndirectSpecularColor: {r: 475.22107, g: 448.39746, b: 454.5464, a: 1}
   m_UseRadianceAmbientProbe: 0
 --- !u!157 &3
 LightmapSettings:
@@ -1609,37 +1609,6 @@ MeshFilter:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 106805989}
   m_Mesh: {fileID: 10202, guid: 0000000000000000e000000000000000, type: 0}
---- !u!1 &119118473
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 119118474}
-  m_Layer: 0
-  m_Name: Spawnables
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &119118474
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 119118473}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 2146880290}
-  m_RootOrder: 1
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &128006127
 GameObject:
   m_ObjectHideFlags: 0
@@ -2080,7 +2049,6 @@ Transform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children:
-  - {fileID: 2146880290}
   - {fileID: 1196933170}
   - {fileID: 580930030}
   m_Father: {fileID: 0}
@@ -3647,7 +3615,7 @@ Transform:
   - {fileID: 646365371}
   - {fileID: 9147915}
   m_Father: {fileID: 207337770}
-  m_RootOrder: 2
+  m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!114 &580930031
 MonoBehaviour:
@@ -3938,9 +3906,9 @@ Transform:
   m_LocalScale: {x: 4, y: 4, z: 4}
   m_ConstrainProportionsScale: 1
   m_Children:
-  - {fileID: 1608220473}
   - {fileID: 919445673}
   - {fileID: 2055433412}
+  - {fileID: 1608220473}
   m_Father: {fileID: 580930030}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -3989,7 +3957,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 0ad34abafad169848a38072baa96cdb2, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  m_InteractionManager: {fileID: 975255379}
+  m_InteractionManager: {fileID: 804422460}
   m_Colliders:
   - {fileID: 646365376}
   m_InteractionLayerMask:
@@ -4116,286 +4084,12 @@ SphereCollider:
   serializedVersion: 2
   m_Radius: 0.5
   m_Center: {x: 0, y: 0, z: 0}
---- !u!1 &654393738
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 654393739}
-  - component: {fileID: 654393744}
-  - component: {fileID: 654393743}
-  - component: {fileID: 654393740}
-  m_Layer: 11
-  m_Name: SphereAnchor
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &654393739
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 654393738}
-  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 2, y: 2, z: 2}
-  m_ConstrainProportionsScale: 1
-  m_Children:
-  - {fileID: 1024841705}
-  - {fileID: 719557997}
-  m_Father: {fileID: 2146880290}
-  m_RootOrder: 0
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!135 &654393740
-SphereCollider:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 654393738}
-  m_Material: {fileID: 0}
-  m_IsTrigger: 0
-  m_Enabled: 0
-  serializedVersion: 2
-  m_Radius: 0.5
-  m_Center: {x: 0, y: 0, z: 0}
---- !u!54 &654393743
-Rigidbody:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 654393738}
-  serializedVersion: 2
-  m_Mass: 500
-  m_Drag: 10
-  m_AngularDrag: 1
-  m_UseGravity: 0
-  m_IsKinematic: 0
-  m_Interpolate: 1
-  m_Constraints: 0
-  m_CollisionDetection: 1
---- !u!114 &654393744
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 654393738}
-  m_Enabled: 0
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 0ad34abafad169848a38072baa96cdb2, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_InteractionManager: {fileID: 975255379}
-  m_Colliders:
-  - {fileID: 654393740}
-  m_InteractionLayerMask:
-    serializedVersion: 2
-    m_Bits: 4294967295
-  m_InteractionLayers:
-    m_Bits: 4294967295
-  m_DistanceCalculationMode: 1
-  m_SelectMode: 0
-  m_CustomReticle: {fileID: 0}
-  m_FirstHoverEntered:
-    m_PersistentCalls:
-      m_Calls: []
-  m_LastHoverExited:
-    m_PersistentCalls:
-      m_Calls: []
-  m_HoverEntered:
-    m_PersistentCalls:
-      m_Calls: []
-  m_HoverExited:
-    m_PersistentCalls:
-      m_Calls: []
-  m_FirstSelectEntered:
-    m_PersistentCalls:
-      m_Calls: []
-  m_LastSelectExited:
-    m_PersistentCalls:
-      m_Calls: []
-  m_SelectEntered:
-    m_PersistentCalls:
-      m_Calls: []
-  m_SelectExited:
-    m_PersistentCalls:
-      m_Calls: []
-  m_Activated:
-    m_PersistentCalls:
-      m_Calls: []
-  m_Deactivated:
-    m_PersistentCalls:
-      m_Calls: []
-  m_StartingHoverFilters: []
-  m_StartingSelectFilters: []
-  m_OnFirstHoverEntered:
-    m_PersistentCalls:
-      m_Calls: []
-  m_OnLastHoverExited:
-    m_PersistentCalls:
-      m_Calls: []
-  m_OnHoverEntered:
-    m_PersistentCalls:
-      m_Calls: []
-  m_OnHoverExited:
-    m_PersistentCalls:
-      m_Calls: []
-  m_OnSelectEntered:
-    m_PersistentCalls:
-      m_Calls: []
-  m_OnSelectExited:
-    m_PersistentCalls:
-      m_Calls: []
-  m_OnSelectCanceled:
-    m_PersistentCalls:
-      m_Calls: []
-  m_OnActivate:
-    m_PersistentCalls:
-      m_Calls: []
-  m_OnDeactivate:
-    m_PersistentCalls:
-      m_Calls: []
-  m_AttachTransform: {fileID: 0}
-  m_UseDynamicAttach: 1
-  m_MatchAttachPosition: 0
-  m_MatchAttachRotation: 1
-  m_SnapToColliderVolume: 1
-  m_AttachEaseInTime: 0.15
-  m_MovementType: 0
-  m_VelocityDamping: 0.9
-  m_VelocityScale: 0.25
-  m_AngularVelocityDamping: 0.7
-  m_AngularVelocityScale: 1
-  m_TrackPosition: 1
-  m_SmoothPosition: 1
-  m_SmoothPositionAmount: 15
-  m_TightenPosition: 0.2
-  m_TrackRotation: 1
-  m_SmoothRotation: 1
-  m_SmoothRotationAmount: 10
-  m_TightenRotation: 0.3
-  m_ThrowOnDetach: 1
-  m_ThrowSmoothingDuration: 0.25
-  m_ThrowSmoothingCurve:
-    serializedVersion: 2
-    m_Curve:
-    - serializedVersion: 3
-      time: 1
-      value: 1
-      inSlope: 0
-      outSlope: 0
-      tangentMode: 0
-      weightedMode: 0
-      inWeight: 0
-      outWeight: 0
-    m_PreInfinity: 2
-    m_PostInfinity: 2
-    m_RotationOrder: 4
-  m_ThrowVelocityScale: 2
-  m_ThrowAngularVelocityScale: 1
-  m_ForceGravityOnDetach: 0
-  m_RetainTransformParent: 1
-  m_AttachPointCompatibilityMode: 0
-  m_StartingSingleGrabTransformers: []
-  m_StartingMultipleGrabTransformers: []
-  m_AddDefaultGrabTransformers: 1
 --- !u!4 &669638862 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 1953932766872481930, guid: e00b6008e2d833a4aad351c9f65c83cd,
     type: 3}
   m_PrefabInstance: {fileID: 1953932767394254916}
   m_PrefabAsset: {fileID: 0}
---- !u!1 &719557996
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 719557997}
-  - component: {fileID: 719557999}
-  - component: {fileID: 719557998}
-  m_Layer: 0
-  m_Name: SphereShape
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 1
-  m_IsActive: 1
---- !u!4 &719557997
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 719557996}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 654393739}
-  m_RootOrder: 1
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!23 &719557998
-MeshRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 719557996}
-  m_Enabled: 1
-  m_CastShadows: 1
-  m_ReceiveShadows: 1
-  m_DynamicOccludee: 1
-  m_StaticShadowCaster: 0
-  m_MotionVectors: 1
-  m_LightProbeUsage: 1
-  m_ReflectionProbeUsage: 1
-  m_RayTracingMode: 2
-  m_RayTraceProcedural: 0
-  m_RenderingLayerMask: 257
-  m_RendererPriority: 0
-  m_Materials:
-  - {fileID: 2100000, guid: cb24d732a4cbfbc48ab9716369e833bd, type: 2}
-  m_StaticBatchInfo:
-    firstSubMesh: 0
-    subMeshCount: 0
-  m_StaticBatchRoot: {fileID: 0}
-  m_ProbeAnchor: {fileID: 0}
-  m_LightProbeVolumeOverride: {fileID: 0}
-  m_ScaleInLightmap: 1
-  m_ReceiveGI: 2
-  m_PreserveUVs: 0
-  m_IgnoreNormalsForChartDetection: 0
-  m_ImportantGI: 0
-  m_StitchLightmapSeams: 1
-  m_SelectedEditorRenderState: 3
-  m_MinimumChartSize: 4
-  m_AutoUVMaxDistance: 0.5
-  m_AutoUVMaxAngle: 89
-  m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: 0
-  m_SortingLayer: 0
-  m_SortingOrder: 0
-  m_AdditionalVertexStreams: {fileID: 0}
---- !u!33 &719557999
-MeshFilter:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 719557996}
-  m_Mesh: {fileID: 10207, guid: 0000000000000000e000000000000000, type: 0}
 --- !u!1 &735958568
 GameObject:
   m_ObjectHideFlags: 0
@@ -5011,6 +4705,7 @@ GameObject:
   - component: {fileID: 804422459}
   - component: {fileID: 804422458}
   - component: {fileID: 804422457}
+  - component: {fileID: 804422460}
   m_Layer: 0
   m_Name: XR Origin
   m_TagString: Untagged
@@ -5166,6 +4861,20 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   m_Timeout: 10
   m_XROrigin: {fileID: 804422455}
+--- !u!114 &804422460
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 804422453}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 83e4e6cca11330d4088d729ab4fc9d9f, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_StartingHoverFilters: []
+  m_StartingSelectFilters: []
 --- !u!1 &881096802
 GameObject:
   m_ObjectHideFlags: 0
@@ -5550,7 +5259,7 @@ Transform:
   m_ConstrainProportionsScale: 1
   m_Children: []
   m_Father: {fileID: 646365371}
-  m_RootOrder: 1
+  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!23 &919445674
 MeshRenderer:
@@ -5871,52 +5580,6 @@ MonoBehaviour:
   m_DeselectOnBackgroundClick: 1
   m_PointerBehavior: 0
   m_CursorLockBehavior: 0
---- !u!1 &975255378
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 975255380}
-  - component: {fileID: 975255379}
-  m_Layer: 19
-  m_Name: XR Interaction Manager
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!114 &975255379
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 975255378}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 83e4e6cca11330d4088d729ab4fc9d9f, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_StartingHoverFilters: []
-  m_StartingSelectFilters: []
---- !u!4 &975255380
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 975255378}
-  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 1221644288}
-  m_RootOrder: 1
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &981386407
 GameObject:
   m_ObjectHideFlags: 0
@@ -6108,52 +5771,6 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1012853350}
   m_CullTransparentMesh: 1
---- !u!1 &1024841704
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 1024841705}
-  - component: {fileID: 1024841706}
-  m_Layer: 0
-  m_Name: InvertedCollider
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &1024841705
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1024841704}
-  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 0.99, y: 0.99, z: 0.99}
-  m_ConstrainProportionsScale: 1
-  m_Children: []
-  m_Father: {fileID: 654393739}
-  m_RootOrder: 0
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!64 &1024841706
-MeshCollider:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1024841704}
-  m_Material: {fileID: 13400000, guid: 28d9ebf37e6d4d94c90d386423d2ef0c, type: 2}
-  m_IsTrigger: 0
-  m_Enabled: 1
-  serializedVersion: 4
-  m_Convex: 1
-  m_CookingOptions: 30
-  m_Mesh: {fileID: 6394535255511023405, guid: 8554b3d2b4ad7e84fb43e6182ece8761, type: 3}
 --- !u!1 &1074502016
 GameObject:
   m_ObjectHideFlags: 0
@@ -6663,7 +6280,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 6803edce0201f574f923fd9d10e5b30a, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  m_InteractionManager: {fileID: 975255379}
+  m_InteractionManager: {fileID: 0}
   m_InteractionLayerMask:
     serializedVersion: 2
     m_Bits: 4294967295
@@ -7508,7 +7125,7 @@ Transform:
   - {fileID: 1647814128}
   - {fileID: 19176485}
   m_Father: {fileID: 207337770}
-  m_RootOrder: 1
+  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!114 &1196933171
 MonoBehaviour:
@@ -7773,7 +7390,6 @@ Transform:
   m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 961816295}
-  - {fileID: 975255380}
   - {fileID: 1521040266}
   m_Father: {fileID: 0}
   m_RootOrder: 4
@@ -8584,7 +8200,7 @@ Transform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1221644288}
-  m_RootOrder: 2
+  m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!65 &1521040267
 BoxCollider:
@@ -9224,7 +8840,7 @@ Transform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 646365371}
-  m_RootOrder: 0
+  m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!64 &1608220474
 MeshCollider:
@@ -9257,6 +8873,11 @@ PrefabInstance:
       propertyPath: m_Mass
       value: 5
       objectReference: {fileID: 0}
+    - target: {fileID: 3243681516917150323, guid: 11c1f9d0af0b04b4695e77e740ea6b3b,
+        type: 3}
+      propertyPath: m_InteractionManager
+      value: 
+      objectReference: {fileID: 804422460}
     - target: {fileID: 3243681516917150324, guid: 11c1f9d0af0b04b4695e77e740ea6b3b,
         type: 3}
       propertyPath: m_RootOrder
@@ -9423,7 +9044,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 0ad34abafad169848a38072baa96cdb2, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  m_InteractionManager: {fileID: 975255379}
+  m_InteractionManager: {fileID: 804422460}
   m_Colliders:
   - {fileID: 1647814132}
   m_InteractionLayerMask:
@@ -9574,6 +9195,11 @@ PrefabInstance:
   m_Modification:
     m_TransformParent: {fileID: 1162212145}
     m_Modifications:
+    - target: {fileID: 116781364290803945, guid: 26c8df6390d44ff46af7ca002dacda5f,
+        type: 3}
+      propertyPath: m_InteractionManager
+      value: 
+      objectReference: {fileID: 804422460}
     - target: {fileID: 116781364290803950, guid: 26c8df6390d44ff46af7ca002dacda5f,
         type: 3}
       propertyPath: m_RootOrder
@@ -10782,7 +10408,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 6803edce0201f574f923fd9d10e5b30a, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  m_InteractionManager: {fileID: 975255379}
+  m_InteractionManager: {fileID: 0}
   m_InteractionLayerMask:
     serializedVersion: 2
     m_Bits: 4294967295
@@ -11252,7 +10878,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 0ad34abafad169848a38072baa96cdb2, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  m_InteractionManager: {fileID: 975255379}
+  m_InteractionManager: {fileID: 804422460}
   m_Colliders:
   - {fileID: 1811036116}
   m_InteractionLayerMask:
@@ -12369,7 +11995,7 @@ Transform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 646365371}
-  m_RootOrder: 2
+  m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!23 &2055433414
 MeshRenderer:
@@ -12951,83 +12577,6 @@ MonoBehaviour:
   m_PointlightHDType: 0
   m_SpotLightShape: 0
   m_AreaLightShape: 0
---- !u!1 &2146880289
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 2146880290}
-  - component: {fileID: 2146880291}
-  m_Layer: 0
-  m_Name: SphereSpawnerOld
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 0
---- !u!4 &2146880290
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2146880289}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children:
-  - {fileID: 654393739}
-  - {fileID: 119118474}
-  m_Father: {fileID: 207337770}
-  m_RootOrder: 0
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &2146880291
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2146880289}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: abaa7077d43660243b3aa238516d9d30, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  _Initialised: 0
-  _ObjectCounter: 0
-  _SecondsSinceSpawn: 0
-  _ControllerObject: {fileID: 654393738}
-  _SpawnableHost: {fileID: 119118473}
-  _PrefabToSpawn: {fileID: 7410472104914952606}
-  _RandomiseSpawnPrefab: 0
-  _SpawnablePrefabs: []
-  _ActiveObjects: []
-  _SpawnablesAllocated: 1
-  _SpawnPeriodSeconds: 0.1
-  _SpawnCondition: 1
-  _SpawnDelaySeconds: 2
-  _AutoSpawn: 1
-  _AutoRemove: 1
-  _EjectionDirection: {x: 0, y: 0, z: 0}
-  _EjectionDirectionVariance: 1
-  _EjectionRadiusRange: {x: 5, y: 10}
-  _EjectionSpeedRange: {x: 5, y: 10}
-  _DestroyOnAllCollisions: 0
-  _BoundingAreaType: 2
-  _BoundingCollider: {fileID: 0}
-  _BoundingRadius: 30
-  _UseSpawnDuration: 1
-  _SpawnObjectDuration: {x: 5, y: 10}
-  _AllowSiblingSurfaceContact: 1
-  _AllowSiblingCollisionTrigger: 1
-  _EmissiveFlashTrigger: 1
-  _EmissiveBrightness: {x: -10, y: 10}
-  _EmissiveFlashFade: 0.5
-  _ControllerRenderers: []
 --- !u!4 &331703749975080555
 Transform:
   m_ObjectHideFlags: 0
@@ -13054,7 +12603,7 @@ PrefabInstance:
         type: 3}
       propertyPath: m_InteractionManager
       value: 
-      objectReference: {fileID: 975255379}
+      objectReference: {fileID: 804422460}
     - target: {fileID: 3855671869938862442, guid: 02ec51453b34a444bb3fa1cd193668aa,
         type: 3}
       propertyPath: m_UseGravity
@@ -13519,6 +13068,11 @@ PrefabInstance:
   m_Modification:
     m_TransformParent: {fileID: 1162212145}
     m_Modifications:
+    - target: {fileID: 116781364290803945, guid: 26c8df6390d44ff46af7ca002dacda5f,
+        type: 3}
+      propertyPath: m_InteractionManager
+      value: 
+      objectReference: {fileID: 804422460}
     - target: {fileID: 116781364290803950, guid: 26c8df6390d44ff46af7ca002dacda5f,
         type: 3}
       propertyPath: m_RootOrder
@@ -13601,6 +13155,8 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   _SpeakerTarget: {fileID: 0}
   _SpeakerTransform: {fileID: 0}
+  _AttachmentRenderer: {fileID: 7410472104914952604}
+  _EmissionRange: {x: 2, y: 10}
   _Spawner: {fileID: 0}
   _SpawnLife: {fileID: 0}
   _LocalTransform: {fileID: 0}
@@ -13727,7 +13283,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 0ad34abafad169848a38072baa96cdb2, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  m_InteractionManager: {fileID: 0}
+  m_InteractionManager: {fileID: 804422460}
   m_Colliders:
   - {fileID: 7410472104914952602}
   m_InteractionLayerMask:

--- a/Assets/_Project/Scenes/PlaneWaver_Demo.unity
+++ b/Assets/_Project/Scenes/PlaneWaver_Demo.unity
@@ -38,7 +38,7 @@ RenderSettings:
   m_ReflectionIntensity: 1
   m_CustomReflection: {fileID: 0}
   m_Sun: {fileID: 2138677392}
-  m_IndirectSpecularColor: {r: 475.22107, g: 448.39746, b: 454.5464, a: 1}
+  m_IndirectSpecularColor: {r: 472.7173, g: 447.7954, b: 464.9668, a: 1}
   m_UseRadianceAmbientProbe: 0
 --- !u!157 &3
 LightmapSettings:
@@ -487,16 +487,16 @@ MonoBehaviour:
   _SpawnDelaySeconds: 2
   _AutoSpawn: 1
   _AutoRemove: 1
-  _EjectionDirection: {x: 0, y: -1, z: 0}
-  _EjectionDirectionVariance: 0.5
+  _EjectionDirection: {x: -1, y: 0, z: 0}
+  _EjectionDirectionVariance: 0.2
   _EjectionRadiusRange: {x: 0.5, y: 0.5}
-  _EjectionSpeedRange: {x: 5, y: 10}
+  _EjectionSpeedRange: {x: 4, y: 8}
   _DestroyOnAllCollisions: 0
   _BoundingAreaType: 1
   _BoundingCollider: {fileID: 0}
   _BoundingRadius: 30
   _UseSpawnDuration: 1
-  _SpawnObjectDuration: {x: 6, y: 8}
+  _SpawnObjectDuration: {x: 3, y: 6}
   _AllowSiblingSurfaceContact: 1
   _AllowSiblingCollisionTrigger: 1
   _EmissiveFlashTrigger: 1
@@ -669,7 +669,7 @@ MonoBehaviour:
   _SpeakerGrainArraySize: 100
   _SpeakerBusyLoadLimit: 0.5
   _SpeakerAttachArcDegrees: 20
-  _SpeakerTrackingSpeed: 10
+  _SpeakerTrackingSpeed: 20
   _SpeakerLingerTime: 300
   _StatsValuesText: {fileID: 1931825995}
   _StatsValuesPeakText: {fileID: 475395361}

--- a/Assets/_Project/Scripts/Entities/EmitterAuthoring.cs
+++ b/Assets/_Project/Scripts/Entities/EmitterAuthoring.cs
@@ -101,7 +101,7 @@ namespace PlaneWaver
             InitialiseModulationInputs();
 
             _EntityManager = World.DefaultGameObjectInjectionWorld.EntityManager;
-            SetIndex(GrainSynth.Instance.RegisterEmitter(this));
+            SetIndex(GrainBrain.Instance.RegisterEmitter(this));
         }
 
         public virtual ModulationInput[] GatherModulationInputs() { return new ModulationInput[0]; }
@@ -154,7 +154,7 @@ namespace PlaneWaver
 
         public override void Deregister()
         {
-            GrainSynth.Instance.DeregisterEmitter(this);
+            GrainBrain.Instance.DeregisterEmitter(this);
         }
 
         #endregion
@@ -172,7 +172,7 @@ namespace PlaneWaver
         {
             if (_EmitterType == EmitterType.Burst && _PlaybackCondition != Condition.NotColliding)
             {
-                if (Time.fixedTime < _LastTriggeredAt + GrainSynth.Instance._BurstDebounceDurationMS * 0.001f)
+                if (Time.fixedTime < _LastTriggeredAt + GrainBrain.Instance._BurstDebounceDurationMS * 0.001f)
                     return;
 
                 if (ColliderMoreRigid(collision.collider, _Host.SurfaceRigidity, out float otherRigidity) && OnlyTriggerMostRigid)
@@ -216,7 +216,7 @@ namespace PlaneWaver
             }
         }
 
-        protected bool OnlyTriggerMostRigid => GrainSynth.Instance._OnlyTriggerMostRigidSurface;
+        protected bool OnlyTriggerMostRigid => GrainBrain.Instance._OnlyTriggerMostRigidSurface;
 
         public static bool ColliderMoreRigid(Collider collider, float rigidity, out float otherRigidity)
         {

--- a/Assets/_Project/Scripts/Entities/HostAuthoring.cs
+++ b/Assets/_Project/Scripts/Entities/HostAuthoring.cs
@@ -100,8 +100,8 @@ namespace PlaneWaver
             InitialiseModules();
 
             _EntityManager = World.DefaultGameObjectInjectionWorld.EntityManager;
-            _Archetype = _EntityManager.CreateArchetype(typeof(Translation), typeof(HostComponent));
-            SetIndex(GrainSynth.Instance.RegisterHost(this));
+            _Archetype = _EntityManager.CreateArchetype(typeof(HostComponent));
+            SetIndex(GrainBrain.Instance.RegisterHost(this));
         }
 
         public void InitialiseModules()
@@ -135,7 +135,7 @@ namespace PlaneWaver
                 _CollisionPipeComponent.AddHost(this);
             }
 
-            _SpeakerTarget = _SpeakerTarget != null ? _SpeakerTarget : transform;
+            _SpeakerTarget = _SpeakerTarget != null ? _SpeakerTarget : _LocalTransform;
             _SpeakerTransform = _SpeakerTarget;
             _HeadTransform = FindObjectOfType<Camera>().transform;
 
@@ -173,25 +173,24 @@ namespace PlaneWaver
 
         public override void InitialiseComponents()
         {
-            _EntityManager.SetComponentData(_Entity, new Translation { Value = _SpeakerTarget.position });
             _EntityManager.SetComponentData(_Entity, new HostComponent
             {
                 _HostIndex = _EntityIndex,
                 _Connected = false,
                 _SpeakerIndex = int.MaxValue,
-                _InListenerRadius = InListenerRadius
+                _InListenerRadius = InListenerRadius,
+                _WorldPos = _SpeakerTarget.position
             });
         }
 
         public override void ProcessComponents()
         {
-            _EntityManager.SetComponentData(_Entity, new Translation { Value = _SpeakerTarget.position });
-
             HostComponent hostData = _EntityManager.GetComponentData<HostComponent>(_Entity);
             hostData._HostIndex = _EntityIndex;
+            hostData._WorldPos = _SpeakerTarget.position;
             _EntityManager.SetComponentData(_Entity, hostData);
 
-            bool connected = GrainSynth.Instance.IsSpeakerAtIndex(hostData._SpeakerIndex, out SpeakerAuthoring speaker);
+            bool connected = GrainBrain.Instance.IsSpeakerAtIndex(hostData._SpeakerIndex, out SpeakerAuthoring speaker);
             _InListenerRadius = hostData._InListenerRadius;
             _SpeakerTransform = connected ? speaker.gameObject.transform : _SpeakerTarget;
             _AttachedSpeakerIndex = connected ? hostData._SpeakerIndex : int.MaxValue;
@@ -204,19 +203,19 @@ namespace PlaneWaver
                 transform.position,
                 _HeadTransform.position,
                 _SpeakerTransform.position);
-
-            _ListenerDistance = Mathf.Abs((_SpeakerTarget.position - _HeadTransform.position).magnitude);
+            
+            _ListenerDistance = Vector3.Distance(_SpeakerTarget.position, _HeadTransform.position);
 
             foreach (EmitterAuthoring emitter in _HostedEmitters)
             {
-                emitter.UpdateDistanceAmplitude(_ListenerDistance / GrainSynth.Instance._ListenerRadius, speakerAmplitudeFactor);
+                emitter.UpdateDistanceAmplitude(_ListenerDistance / GrainBrain.Instance._ListenerRadius, speakerAmplitudeFactor);
             }
         }
 
         public override void Deregister()
         {
-            if (GrainSynth.Instance != null)
-                GrainSynth.Instance.DeregisterHost(this);
+            if (GrainBrain.Instance != null)
+                GrainBrain.Instance.DeregisterHost(this);
             if (_CollisionPipeComponent != null)
                 _CollisionPipeComponent.RemoveHost(this);
         }
@@ -250,7 +249,7 @@ namespace PlaneWaver
         {
             if (_AttachmentLine != null)
             {
-                if (_Connected && _SpeakerTransform != _SpeakerTarget && GrainSynth.Instance._DrawAttachmentLines)
+                if (_Connected && _SpeakerTransform != _SpeakerTarget && GrainBrain.Instance._DrawAttachmentLines)
                 {
                     _AttachmentLine._Active = true;
                     _AttachmentLine._TransformB = _SpeakerTransform;

--- a/Assets/_Project/Scripts/Entities/HostAuthoring.cs
+++ b/Assets/_Project/Scripts/Entities/HostAuthoring.cs
@@ -21,12 +21,19 @@ namespace PlaneWaver
         private Transform _HeadTransform;
 
         [AllowNesting]
-        [BoxGroup("Speaker Assignment")]
+        [BoxGroup("Speaker Attachment")]
         [Tooltip("Parent transform position for speakers to target for this host. Defaults to this transform.")]
         [SerializeField] private Transform _SpeakerTarget;
         [AllowNesting]
-        [BoxGroup("Speaker Assignment")]
+        [BoxGroup("Speaker Attachment")]
         [SerializeField] private Transform _SpeakerTransform;
+        [AllowNesting]
+        [BoxGroup("Speaker Attachment")]
+        [SerializeField] private Renderer _AttachmentRenderer;
+        [AllowNesting]
+        [BoxGroup("Speaker Attachment")]
+        [MinMaxSlider(-10, 10)] public Vector2 _EmissionRange = new(2, 10);
+        private MaterialColourModulator _MaterialModulator;
 
         private AttachmentLine _AttachmentLine;
 
@@ -116,6 +123,9 @@ namespace PlaneWaver
             _LocalActor = new(_LocalTransform);
             _RemoteActor = _RemoteTransform != null ? new(_RemoteTransform) : null;
 
+            if (_AttachmentRenderer != null)
+                _MaterialModulator = new MaterialColourModulator(_AttachmentRenderer, "_EmissiveColor");
+
             if (_AttachmentLine = TryGetComponent(out _AttachmentLine) ? _AttachmentLine : gameObject.AddComponent<AttachmentLine>())
                 _AttachmentLine._TransformA = _SpeakerTarget;
 
@@ -196,6 +206,7 @@ namespace PlaneWaver
             _AttachedSpeakerIndex = connected ? hostData._SpeakerIndex : int.MaxValue;
             _Connected = connected;
 
+            _MaterialModulator.SetIntensity(connected ? 10 : 1);
             UpdateSpeakerAttachmentLine();
             ProcessRigidity();
 

--- a/Assets/_Project/Scripts/Global/GrainBrain.cs
+++ b/Assets/_Project/Scripts/Global/GrainBrain.cs
@@ -25,11 +25,11 @@ namespace PlaneWaver
     /// Single-instanced manager component that governs the synthesiser's entities and grain delivery.
     /// </summary>
     [RequireComponent(typeof(AudioSource))]
-    public class GrainSynth : MonoBehaviour
+    public class GrainBrain : MonoBehaviour
     {
         #region FIELDS & PROPERTIES
 
-        public static GrainSynth Instance;
+        public static GrainBrain Instance;
 
         private EntityManager _EntityManager;
         private EntityQuery _GrainQuery;
@@ -111,8 +111,9 @@ namespace PlaneWaver
         [BoxGroup("Speaker Configuration")]
         [Tooltip("Length of time in milliseconds before pooling a speaker after its last emitter has disconnected. Allows speakers to be reused without destroying remaining grains from destroyed emitters.")]
         [Range(0, 500)] public float _SpeakerLingerTime = 100;
-        public int SpeakersAllocated { get { return Math.Min(_SpeakersAllocated, _MaxSpeakers); } }
-        public float AttachSmoothing { get { return Mathf.Clamp(Time.deltaTime * _SpeakerTrackingSpeed, 0, 1); } }
+        public int SpeakersAllocated => Math.Min(_SpeakersAllocated, _MaxSpeakers);
+        public bool PopulatingSpeakers => _SpeakersAllocated != _Speakers.Count;
+        public float AttachSmoothing => Mathf.Clamp(Time.deltaTime * _SpeakerTrackingSpeed, 0, 1);
 
         [BoxGroup("Visual Feedback")]
         public TextMeshProUGUI _StatsValuesText;

--- a/Assets/_Project/Scripts/Global/GrainBrain.cs.meta
+++ b/Assets/_Project/Scripts/Global/GrainBrain.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 575024e13d07ce244a554537f81bdf43
+guid: 71a200e41e1c3894daaaa6c184452e30
 MonoImporter:
   externalObjects: {}
   serializedVersion: 2

--- a/Assets/_Project/Scripts/Global/GrainSynthComponents.cs
+++ b/Assets/_Project/Scripts/Global/GrainSynthComponents.cs
@@ -108,6 +108,7 @@ public struct SpeakerComponent : IComponentData
 
 public struct ConnectedTag : IComponentData { }
 public struct InListenerRadiusTag : IComponentData { }
+public struct LoneHostOnSpeakerTag : IComponentData { }
 
 public struct HostComponent : IComponentData
 {

--- a/Assets/_Project/Scripts/Global/GrainSynthComponents.cs
+++ b/Assets/_Project/Scripts/Global/GrainSynthComponents.cs
@@ -95,6 +95,7 @@ public struct SpeakerComponent : IComponentData
     public float _ConnectionRadius;
     public float _InactiveDuration;
     public float _GrainLoad;
+    public float3 _WorldPos;
 }
 
 
@@ -114,6 +115,7 @@ public struct HostComponent : IComponentData
     public int _SpeakerIndex;
     public bool _Connected;
     public bool _InListenerRadius;
+    public float3 _WorldPos;
 }
 public struct PlayingTag : IComponentData { }
 public struct PingPongTag : IComponentData { }

--- a/Assets/_Project/Scripts/Interaction/ObjectSpawner.cs
+++ b/Assets/_Project/Scripts/Interaction/ObjectSpawner.cs
@@ -9,6 +9,7 @@ using NaughtyAttributes;
 using MaxVRAM;
 using MaxVRAM.Ticker;
 using MaxVRAM.Extensions;
+using static PlaneWaver.ObjectSpawner;
 
 namespace PlaneWaver
 {
@@ -94,7 +95,7 @@ namespace PlaneWaver
         [Range(0, 1)][SerializeField] private float _EmissiveFlashFade = 0.5f;
         [Tooltip("Supply list of renderers to modulate/flash emissive brightness on selected triggers.")]
         [SerializeField] private List<Renderer> _ControllerRenderers = new();
-        private List<Color> _EmissiveColours = new();
+        private List<MaterialColourModulator> _EmissiveRenderers = new();
         private float _EmissiveIntensity = 0;
         public bool VisualFeedbackOn => _EmissiveFlashTrigger is not ControllerEvent.Off;
 
@@ -131,10 +132,7 @@ namespace PlaneWaver
                 _ControllerObject = gameObject;
 
             foreach (Renderer renderer in _ControllerRenderers)
-            {
-                Color colour = renderer.material.GetColor("_EmissiveColor");
-                _EmissiveColours.Add(colour);
-            }
+                _EmissiveRenderers.Add(new MaterialColourModulator(renderer, "_EmissiveColor"));
 
             if (_SpawnableHost == null)
                 _SpawnableHost = gameObject;
@@ -283,10 +281,8 @@ namespace PlaneWaver
 
         public void UpdateShaderModulation()
         {
-            for (int i = 0; i < _ControllerRenderers.Count; i++)
-            {
-                _ControllerRenderers[i].material.SetColor("_EmissiveColor", _EmissiveColours[i] * _EmissiveIntensity * 2);
-            }
+            foreach (MaterialColourModulator renderer in _EmissiveRenderers)
+                renderer.SetIntensity(_EmissiveIntensity * 2);
 
             float glow = _EmissiveBrightness.x + (1 + Mathf.Sin(_SecondsSinceSpawn / _SpawnPeriodSeconds * 2)) * 0.5f;
             _EmissiveIntensity = _EmissiveIntensity.Smooth(glow, _EmissiveFlashFade);

--- a/Assets/_Project/Scripts/MaxVRAM/MaxVRAM_math.cs
+++ b/Assets/_Project/Scripts/MaxVRAM/MaxVRAM_math.cs
@@ -5,6 +5,8 @@ namespace MaxVRAM
 {
     public struct MaxMath
     {
+        public static float ONE_DEGREE => 0.0027777777f;
+
         public static float Map(float val, float inMin, float inMax, float outMin, float outMax)
         {
             return (val - inMin) / (inMax - inMin) * (outMax - outMin) + outMin;

--- a/Assets/_Project/Scripts/Systems/AttachmentSystem.cs
+++ b/Assets/_Project/Scripts/Systems/AttachmentSystem.cs
@@ -65,32 +65,27 @@ public partial class AttachmentSystem : SystemBase
                 if (math.distance(host._WorldPos, connectionConfig._ListenerPos) > connectionConfig._ListenerRadius)
                 {
                     host._Connected = false;
-                    host._SpeakerIndex = int.MaxValue;
                     host._InListenerRadius = false;
                     ecb.RemoveComponent<ConnectedTag>(entityInQueryIndex, entity);
                     ecb.RemoveComponent<InListenerRadiusTag>(entityInQueryIndex, entity);
-                }
-                else
-                {
-                    host._InListenerRadius = true;
-                    ecb.AddComponent(entityInQueryIndex, entity, new InListenerRadiusTag());
+                    host._SpeakerIndex = int.MaxValue;
+                    return;
                 }
 
-                if (host._SpeakerIndex < speakerComponents.Length && speakerComponents[host._SpeakerIndex]._State != ConnectionState.Pooled)
-                {
-                    if (math.distance(host._WorldPos, speakerComponents[host._SpeakerIndex]._WorldPos) <
-                        speakerComponents[host._SpeakerIndex]._ConnectionRadius)
-                    {
-                        host._Connected = true;
-                        ecb.AddComponent(entityInQueryIndex, entity, new ConnectedTag());
-                    }
-                }
-                else
+                host._InListenerRadius = true;
+                ecb.AddComponent(entityInQueryIndex, entity, new InListenerRadiusTag());
+
+                if (host._SpeakerIndex >= speakerComponents.Length || math.distance(host._WorldPos,
+                    speakerComponents[host._SpeakerIndex]._WorldPos) > speakerComponents[host._SpeakerIndex]._ConnectionRadius)
                 {
                     host._Connected = false;
                     host._SpeakerIndex = int.MaxValue;
                     ecb.RemoveComponent<ConnectedTag>(entityInQueryIndex, entity);
+                    return;
                 }
+
+                host._Connected = true;
+                ecb.AddComponent(entityInQueryIndex, entity, new ConnectedTag());
             }
         ).WithDisposeOnCompletion(speakerComponents)
         .ScheduleParallel(Dependency);

--- a/Assets/_Project/Scripts/Visual/AttachmentLine.cs
+++ b/Assets/_Project/Scripts/Visual/AttachmentLine.cs
@@ -14,8 +14,8 @@ namespace PlaneWaver
             if (!TryGetComponent(out _Line))
                 _Line = gameObject.AddComponent<LineRenderer>();
             
-            _Line.material = GrainSynth.Instance._AttachmentLineMat;
-            _Line.widthMultiplier = GrainSynth.Instance._AttachmentLineWidth;
+            _Line.material = GrainBrain.Instance._AttachmentLineMat;
+            _Line.widthMultiplier = GrainBrain.Instance._AttachmentLineWidth;
             _Line.positionCount = 2;
 
             if (_TransformA != null)

--- a/Assets/_Project/Scripts/Visual/GrainSynthVisualizer.cs
+++ b/Assets/_Project/Scripts/Visual/GrainSynthVisualizer.cs
@@ -73,8 +73,8 @@ public class GrainSynthVisualizer : MonoBehaviour
         if (_DrawWaveform)
         {
             // Waveform
-            float[] clipData = new float[20]; // [GrainSynth.Instance._AudioClips[0].samples];
-            // GrainSynth.Instance._AudioClips[0].GetData(clipData, 0);
+            float[] clipData = new float[20]; // [GrainBrain.Instance._AudioClips[0].samples];
+            // GrainBrain.Instance._AudioClips[0].GetData(clipData, 0);
             _ClipSampleCount = clipData.Length;
             int samplesPerBlock = clipData.Length / _WaveformBlockCount;
 
@@ -205,13 +205,13 @@ public class GrainSynthVisualizer : MonoBehaviour
                 _XAxisPivot.SetScaleX(_TimelineDistance);
 
             if (Application.isPlaying && _XAxisPivot_FrameTime != null)
-                _XAxisPivot_FrameTime.SetScaleX(-GrainSynth.Instance._QueueDurationMS * .001f * (_TimelineDistance / _TimelineDuration));
+                _XAxisPivot_FrameTime.SetScaleX(-GrainBrain.Instance._QueueDurationMS * .001f * (_TimelineDistance / _TimelineDuration));
 
             for (int i = 0; i < _TimelineBlocks.Length; i++)
             {
                 if (_TimelineBlocks[i].gameObject.activeSelf)
                 {
-                    int sampleDiff = _TimelineBlocks[i]._StartIndex - GrainSynth.Instance.CurrentSampleIndex;
+                    int sampleDiff = _TimelineBlocks[i]._StartIndex - GrainBrain.Instance.CurrentSampleIndex;
                     Vector3 pos = transform.position + transform.right * (sampleDiff / _SampleRate) * (_TimelineDistance / _TimelineDuration);
                     pos.y = _TimelineBlocks[i].transform.position.y;
 
@@ -246,7 +246,7 @@ public class GrainSynthVisualizer : MonoBehaviour
 
     Vector3 PosFromStartSampleIndex(int startSampleIndex)
     {
-        int sampleDiff = startSampleIndex - GrainSynth.Instance.CurrentSampleIndex;
+        int sampleDiff = startSampleIndex - GrainBrain.Instance.CurrentSampleIndex;
         Vector3 pos = transform.position + transform.right * (sampleDiff / _SampleRate) * (_TimelineDistance / _TimelineDuration);
 
         pos.y += (_IncrementY % _TimelineHeightCount) * _TimelineScale;

--- a/Assets/_Project/Scripts/Visual/MaterialColourModulator.cs
+++ b/Assets/_Project/Scripts/Visual/MaterialColourModulator.cs
@@ -1,0 +1,49 @@
+using UnityEngine;
+
+using MaxVRAM.Extensions;
+
+namespace PlaneWaver
+{
+    public struct MaterialColourModulator
+    {
+        private Renderer _Renderer;
+        private Color _Colour;
+        private string _ColourParam;
+        private float _CurrentIntensity;
+        private float _Smoothing;
+        public float Smoothing { get => _Smoothing; set => _Smoothing = value; }
+
+        public MaterialColourModulator(Renderer renderer, string colourParamName)
+        {
+            _Renderer = renderer;
+            _Colour = renderer.material.GetColor(colourParamName);
+            _ColourParam = colourParamName;
+            _CurrentIntensity = 1;
+            _Smoothing = 0.5f;
+    }
+
+        public MaterialColourModulator(Renderer renderer, Color colour, string colourParamName)
+        {
+            _Renderer = renderer;
+            _Colour = colour;
+            _ColourParam = colourParamName;
+            _CurrentIntensity = 1;
+            _Smoothing = 0.5f;
+        }
+
+        public void SetIntensity(float intensity)
+        {
+            if (_Renderer != null)
+            {
+                _CurrentIntensity = _CurrentIntensity.Smooth(intensity, _Smoothing);
+                _Renderer.material.SetColor(_ColourParam, _Colour * _CurrentIntensity);
+            }
+        }
+
+        public void SetColour(Color colour)
+        {
+            if (_Renderer != null)
+                _Renderer.material.SetColor(_ColourParam, colour);
+        }
+    }
+}

--- a/Assets/_Project/Scripts/Visual/MaterialColourModulator.cs.meta
+++ b/Assets/_Project/Scripts/Visual/MaterialColourModulator.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 8fd359df7bf5ab34fa4e5c8daeaa5a41
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ProjectSettings/AudioManager.asset
+++ b/ProjectSettings/AudioManager.asset
@@ -11,7 +11,7 @@ AudioManager:
   m_SampleRate: 44100
   m_DSPBufferSize: 512
   m_VirtualVoiceCount: 1024
-  m_RealVoiceCount: 255
+  m_RealVoiceCount: 64
   m_EnableOutputSuspension: 0
   m_SpatializerPlugin: OculusSpatializer
   m_AmbisonicDecoderPlugin: OculusSpatializer


### PR DESCRIPTION
- Hosts will now drop its current speaker and attach to another if:
  - The host's current speaker has no other hosts attached
  - The other speaker is in range, has an active state, and either:
    - More than 2 or more hosts already attached, or
    - 1 host attached and has been active longer than the current speaker
- Several other small optimisations to the attachment system jobs
- Fixed some incorrectly assigned `ref` parameters in Synthesiser system jobs to `in` to improve performance
- General tidying of attachment and synthesiser systems